### PR TITLE
[Website Docs] Add Tab to header

### DIFF
--- a/website/docs/d/avi_actiongroupconfig.html.markdown
+++ b/website/docs/d/avi_actiongroupconfig.html.markdown
@@ -3,7 +3,7 @@ layout: "avi"
 page_title: "AVI: avi_actiongroupconfig"
 sidebar_current: "docs-avi-datasource-actiongroupconfig"
 description: |-
-Get information of Avi ActionGroupConfig.
+  Get information of Avi ActionGroupConfig.
 ---
 
 # avi_actiongroupconfig
@@ -39,4 +39,3 @@ In addition to all arguments above, the following attributes are exported:
 * `syslog_config_ref` - Select the syslog notification configuration to use when sending alerts via syslog.
 * `tenant_ref` - It is a reference to an object of type tenant.
 * `uuid` - General description.
-

--- a/website/docs/d/avi_alertconfig.html.markdown
+++ b/website/docs/d/avi_alertconfig.html.markdown
@@ -3,7 +3,7 @@ layout: "avi"
 page_title: "AVI: avi_alertconfig"
 sidebar_current: "docs-avi-datasource-alertconfig"
 description: |-
-Get information of Avi AlertConfig.
+  Get information of Avi AlertConfig.
 ---
 
 # avi_alertconfig
@@ -46,4 +46,3 @@ In addition to all arguments above, the following attributes are exported:
 * `threshold` - An alert is created only when the number of events meets or exceeds this number within the chosen time frame.
 * `throttle` - Alerts are suppressed (throttled) for this duration of time since the last alert was raised for this alert config.
 * `uuid` - General description.
-

--- a/website/docs/d/avi_alertemailconfig.html.markdown
+++ b/website/docs/d/avi_alertemailconfig.html.markdown
@@ -3,7 +3,7 @@ layout: "avi"
 page_title: "AVI: avi_alertemailconfig"
 sidebar_current: "docs-avi-datasource-alertemailconfig"
 description: |-
-Get information of Avi AlertEmailConfig.
+  Get information of Avi AlertEmailConfig.
 ---
 
 # avi_alertemailconfig
@@ -34,4 +34,3 @@ In addition to all arguments above, the following attributes are exported:
 * `tenant_ref` - It is a reference to an object of type tenant.
 * `to_emails` - Alerts are sent to the comma separated list of  email recipients.
 * `uuid` - General description.
-

--- a/website/docs/d/avi_alertscriptconfig.html.markdown
+++ b/website/docs/d/avi_alertscriptconfig.html.markdown
@@ -3,7 +3,7 @@ layout: "avi"
 page_title: "AVI: avi_alertscriptconfig"
 sidebar_current: "docs-avi-datasource-alertscriptconfig"
 description: |-
-Get information of Avi AlertScriptConfig.
+  Get information of Avi AlertScriptConfig.
 ---
 
 # avi_alertscriptconfig
@@ -32,4 +32,3 @@ In addition to all arguments above, the following attributes are exported:
 * `name` - A user-friendly name of the script.
 * `tenant_ref` - It is a reference to an object of type tenant.
 * `uuid` - General description.
-

--- a/website/docs/d/avi_alertsyslogconfig.html.markdown
+++ b/website/docs/d/avi_alertsyslogconfig.html.markdown
@@ -3,7 +3,7 @@ layout: "avi"
 page_title: "AVI: avi_alertsyslogconfig"
 sidebar_current: "docs-avi-datasource-alertsyslogconfig"
 description: |-
-Get information of Avi AlertSyslogConfig.
+  Get information of Avi AlertSyslogConfig.
 ---
 
 # avi_alertsyslogconfig
@@ -33,4 +33,3 @@ In addition to all arguments above, the following attributes are exported:
 * `syslog_servers` - The list of syslog servers.
 * `tenant_ref` - It is a reference to an object of type tenant.
 * `uuid` - General description.
-

--- a/website/docs/d/avi_analyticsprofile.html.markdown
+++ b/website/docs/d/avi_analyticsprofile.html.markdown
@@ -3,7 +3,7 @@ layout: "avi"
 page_title: "AVI: avi_analyticsprofile"
 sidebar_current: "docs-avi-datasource-analyticsprofile"
 description: |-
-Get information of Avi AnalyticsProfile.
+  Get information of Avi AnalyticsProfile.
 ---
 
 # avi_analyticsprofile
@@ -99,4 +99,3 @@ In addition to all arguments above, the following attributes are exported:
 * `sensitive_log_profile` - Rules applied to the http application log for filtering sensitive information.
 * `tenant_ref` - It is a reference to an object of type tenant.
 * `uuid` - Uuid of the analytics profile.
-

--- a/website/docs/d/avi_applicationpersistenceprofile.html.markdown
+++ b/website/docs/d/avi_applicationpersistenceprofile.html.markdown
@@ -3,7 +3,7 @@ layout: "avi"
 page_title: "AVI: avi_applicationpersistenceprofile"
 sidebar_current: "docs-avi-datasource-applicationpersistenceprofile"
 description: |-
-Get information of Avi ApplicationPersistenceProfile.
+  Get information of Avi ApplicationPersistenceProfile.
 ---
 
 # avi_applicationpersistenceprofile
@@ -39,4 +39,3 @@ In addition to all arguments above, the following attributes are exported:
 * `server_hm_down_recovery` - Specifies behavior when a persistent server has been marked down by a health monitor.
 * `tenant_ref` - It is a reference to an object of type tenant.
 * `uuid` - Uuid of the persistence profile.
-

--- a/website/docs/d/avi_applicationprofile.html.markdown
+++ b/website/docs/d/avi_applicationprofile.html.markdown
@@ -3,7 +3,7 @@ layout: "avi"
 page_title: "AVI: avi_applicationprofile"
 sidebar_current: "docs-avi-datasource-applicationprofile"
 description: |-
-Get information of Avi ApplicationProfile.
+  Get information of Avi ApplicationProfile.
 ---
 
 # avi_applicationprofile
@@ -40,4 +40,3 @@ In addition to all arguments above, the following attributes are exported:
 * `tenant_ref` - It is a reference to an object of type tenant.
 * `type` - Specifies which application layer proxy is enabled for the virtual service.
 * `uuid` - Uuid of the application profile.
-

--- a/website/docs/d/avi_authprofile.html.markdown
+++ b/website/docs/d/avi_authprofile.html.markdown
@@ -3,7 +3,7 @@ layout: "avi"
 page_title: "AVI: avi_authprofile"
 sidebar_current: "docs-avi-datasource-authprofile"
 description: |-
-Get information of Avi AuthProfile.
+  Get information of Avi AuthProfile.
 ---
 
 # avi_authprofile
@@ -37,4 +37,3 @@ In addition to all arguments above, the following attributes are exported:
 * `tenant_ref` - It is a reference to an object of type tenant.
 * `type` - Type of the auth profile.
 * `uuid` - Uuid of the auth profile.
-

--- a/website/docs/d/avi_autoscalelaunchconfig.html.markdown
+++ b/website/docs/d/avi_autoscalelaunchconfig.html.markdown
@@ -3,7 +3,7 @@ layout: "avi"
 page_title: "AVI: avi_autoscalelaunchconfig"
 sidebar_current: "docs-avi-datasource-autoscalelaunchconfig"
 description: |-
-Get information of Avi AutoScaleLaunchConfig.
+  Get information of Avi AutoScaleLaunchConfig.
 ---
 
 # avi_autoscalelaunchconfig
@@ -36,4 +36,3 @@ In addition to all arguments above, the following attributes are exported:
 * `tenant_ref` - It is a reference to an object of type tenant.
 * `use_external_asg` - If set to true, serverautoscalepolicy will use the autoscaling group (external_autoscaling_groups) from pool to perform scale up and scale down.
 * `uuid` - General description.
-

--- a/website/docs/d/avi_backup.html.markdown
+++ b/website/docs/d/avi_backup.html.markdown
@@ -3,7 +3,7 @@ layout: "avi"
 page_title: "AVI: avi_backup"
 sidebar_current: "docs-avi-datasource-backup"
 description: |-
-Get information of Avi Backup.
+  Get information of Avi Backup.
 ---
 
 # avi_backup
@@ -36,4 +36,3 @@ In addition to all arguments above, the following attributes are exported:
 * `tenant_ref` - It is a reference to an object of type tenant.
 * `timestamp` - Unix timestamp of when the backup file is created.
 * `uuid` - General description.
-

--- a/website/docs/d/avi_backupconfiguration.html.markdown
+++ b/website/docs/d/avi_backupconfiguration.html.markdown
@@ -3,7 +3,7 @@ layout: "avi"
 page_title: "AVI: avi_backupconfiguration"
 sidebar_current: "docs-avi-datasource-backupconfiguration"
 description: |-
-Get information of Avi BackupConfiguration.
+  Get information of Avi BackupConfiguration.
 ---
 
 # avi_backupconfiguration
@@ -39,4 +39,3 @@ In addition to all arguments above, the following attributes are exported:
 * `tenant_ref` - It is a reference to an object of type tenant.
 * `upload_to_remote_host` - Remote backup.
 * `uuid` - General description.
-

--- a/website/docs/d/avi_certificatemanagementprofile.html.markdown
+++ b/website/docs/d/avi_certificatemanagementprofile.html.markdown
@@ -3,7 +3,7 @@ layout: "avi"
 page_title: "AVI: avi_certificatemanagementprofile"
 sidebar_current: "docs-avi-datasource-certificatemanagementprofile"
 description: |-
-Get information of Avi CertificateManagementProfile.
+  Get information of Avi CertificateManagementProfile.
 ---
 
 # avi_certificatemanagementprofile
@@ -33,4 +33,3 @@ In addition to all arguments above, the following attributes are exported:
 * `script_path` - General description.
 * `tenant_ref` - It is a reference to an object of type tenant.
 * `uuid` - General description.
-

--- a/website/docs/d/avi_cloud.html.markdown
+++ b/website/docs/d/avi_cloud.html.markdown
@@ -3,7 +3,7 @@ layout: "avi"
 page_title: "AVI: avi_cloud"
 sidebar_current: "docs-avi-datasource-cloud"
 description: |-
-Get information of Avi Cloud.
+  Get information of Avi Cloud.
 ---
 
 # avi_cloud
@@ -61,4 +61,3 @@ In addition to all arguments above, the following attributes are exported:
 * `vca_configuration` - General description.
 * `vcenter_configuration` - General description.
 * `vtype` - Cloud type.
-

--- a/website/docs/d/avi_cloudconnectoruser.html.markdown
+++ b/website/docs/d/avi_cloudconnectoruser.html.markdown
@@ -3,7 +3,7 @@ layout: "avi"
 page_title: "AVI: avi_cloudconnectoruser"
 sidebar_current: "docs-avi-datasource-cloudconnectoruser"
 description: |-
-Get information of Avi CloudConnectorUser.
+  Get information of Avi CloudConnectorUser.
 ---
 
 # avi_cloudconnectoruser
@@ -37,4 +37,3 @@ In addition to all arguments above, the following attributes are exported:
 * `public_key` - General description.
 * `tenant_ref` - It is a reference to an object of type tenant.
 * `uuid` - General description.
-

--- a/website/docs/d/avi_cloudproperties.html.markdown
+++ b/website/docs/d/avi_cloudproperties.html.markdown
@@ -3,7 +3,7 @@ layout: "avi"
 page_title: "AVI: avi_cloudproperties"
 sidebar_current: "docs-avi-datasource-cloudproperties"
 description: |-
-Get information of Avi CloudProperties.
+  Get information of Avi CloudProperties.
 ---
 
 # avi_cloudproperties
@@ -33,4 +33,3 @@ In addition to all arguments above, the following attributes are exported:
 * `hyp_props` - Hypervisor properties.
 * `info` - Properties specific to a cloud type.
 * `uuid` - General description.
-

--- a/website/docs/d/avi_cluster.html.markdown
+++ b/website/docs/d/avi_cluster.html.markdown
@@ -3,7 +3,7 @@ layout: "avi"
 page_title: "AVI: avi_cluster"
 sidebar_current: "docs-avi-datasource-cluster"
 description: |-
-Get information of Avi Cluster.
+  Get information of Avi Cluster.
 ---
 
 # avi_cluster
@@ -34,4 +34,3 @@ In addition to all arguments above, the following attributes are exported:
 * `tenant_ref` - It is a reference to an object of type tenant.
 * `uuid` - General description.
 * `virtual_ip` - A virtual ip address.
-

--- a/website/docs/d/avi_clusterclouddetails.html.markdown
+++ b/website/docs/d/avi_clusterclouddetails.html.markdown
@@ -3,7 +3,7 @@ layout: "avi"
 page_title: "AVI: avi_clusterclouddetails"
 sidebar_current: "docs-avi-datasource-clusterclouddetails"
 description: |-
-Get information of Avi ClusterCloudDetails.
+  Get information of Avi ClusterCloudDetails.
 ---
 
 # avi_clusterclouddetails
@@ -32,4 +32,3 @@ In addition to all arguments above, the following attributes are exported:
 * `name` - Field introduced in 17.2.5.
 * `tenant_ref` - It is a reference to an object of type tenant.
 * `uuid` - Field introduced in 17.2.5.
-

--- a/website/docs/d/avi_controllerproperties.html.markdown
+++ b/website/docs/d/avi_controllerproperties.html.markdown
@@ -3,7 +3,7 @@ layout: "avi"
 page_title: "AVI: avi_controllerproperties"
 sidebar_current: "docs-avi-datasource-controllerproperties"
 description: |-
-Get information of Avi ControllerProperties.
+  Get information of Avi ControllerProperties.
 ---
 
 # avi_controllerproperties
@@ -84,4 +84,3 @@ In addition to all arguments above, the following attributes are exported:
 * `vs_se_vnic_ip_fail` - General description.
 * `warmstart_se_reconnect_wait_time` - General description.
 * `warmstart_vs_resync_wait_time` - Timeout for warmstart vs resync.
-

--- a/website/docs/d/avi_customipamdnsprofile.html.markdown
+++ b/website/docs/d/avi_customipamdnsprofile.html.markdown
@@ -3,7 +3,7 @@ layout: "avi"
 page_title: "AVI: avi_customipamdnsprofile"
 sidebar_current: "docs-avi-datasource-customipamdnsprofile"
 description: |-
-Get information of Avi CustomIpamDnsProfile.
+  Get information of Avi CustomIpamDnsProfile.
 ---
 
 # avi_customipamdnsprofile
@@ -33,4 +33,3 @@ In addition to all arguments above, the following attributes are exported:
 * `script_uri` - Script uri of form controller //ipamdnsscripts/<file-name>.
 * `tenant_ref` - It is a reference to an object of type tenant.
 * `uuid` - Field introduced in 17.1.1.
-

--- a/website/docs/d/avi_dnspolicy.html.markdown
+++ b/website/docs/d/avi_dnspolicy.html.markdown
@@ -3,7 +3,7 @@ layout: "avi"
 page_title: "AVI: avi_dnspolicy"
 sidebar_current: "docs-avi-datasource-dnspolicy"
 description: |-
-Get information of Avi DnsPolicy.
+  Get information of Avi DnsPolicy.
 ---
 
 # avi_dnspolicy
@@ -34,4 +34,3 @@ In addition to all arguments above, the following attributes are exported:
 * `rule` - Dns rules.
 * `tenant_ref` - It is a reference to an object of type tenant.
 * `uuid` - Uuid of the dns policy.
-

--- a/website/docs/d/avi_errorpagebody.html.markdown
+++ b/website/docs/d/avi_errorpagebody.html.markdown
@@ -3,7 +3,7 @@ layout: "avi"
 page_title: "AVI: avi_errorpagebody"
 sidebar_current: "docs-avi-datasource-errorpagebody"
 description: |-
-Get information of Avi ErrorPageBody.
+  Get information of Avi ErrorPageBody.
 ---
 
 # avi_errorpagebody
@@ -32,4 +32,3 @@ In addition to all arguments above, the following attributes are exported:
 * `name` - Field introduced in 17.2.4.
 * `tenant_ref` - It is a reference to an object of type tenant.
 * `uuid` - Field introduced in 17.2.4.
-

--- a/website/docs/d/avi_errorpageprofile.html.markdown
+++ b/website/docs/d/avi_errorpageprofile.html.markdown
@@ -3,7 +3,7 @@ layout: "avi"
 page_title: "AVI: avi_errorpageprofile"
 sidebar_current: "docs-avi-datasource-errorpageprofile"
 description: |-
-Get information of Avi ErrorPageProfile.
+  Get information of Avi ErrorPageProfile.
 ---
 
 # avi_errorpageprofile
@@ -32,4 +32,3 @@ In addition to all arguments above, the following attributes are exported:
 * `name` - Field introduced in 17.2.4.
 * `tenant_ref` - It is a reference to an object of type tenant.
 * `uuid` - Field introduced in 17.2.4.
-

--- a/website/docs/d/avi_fileservice.html.markdown
+++ b/website/docs/d/avi_fileservice.html.markdown
@@ -3,7 +3,7 @@ layout: "avi"
 page_title: "AVI: avi_fileservice"
 sidebar_current: "docs-avi-datasource-fileservice"
 description: |-
-Get information of Avi Fileservice.
+  Get information of Avi Fileservice.
 ---
 
 # avi_fileservice
@@ -21,7 +21,7 @@ data "avi_fileservice" "foo_Fileservice" {
 ## Argument Reference
 
 * `uuid` - (Optional) Search fileservice object by uuid.
-  
+
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:

--- a/website/docs/d/avi_gslb.html.markdown
+++ b/website/docs/d/avi_gslb.html.markdown
@@ -3,7 +3,7 @@ layout: "avi"
 page_title: "AVI: avi_gslb"
 sidebar_current: "docs-avi-datasource-gslb"
 description: |-
-Get information of Avi Gslb.
+  Get information of Avi Gslb.
 ---
 
 # avi_gslb
@@ -42,4 +42,3 @@ In addition to all arguments above, the following attributes are exported:
 * `third_party_sites` - Third party site member belonging to this gslb.
 * `uuid` - Uuid of the gslb object.
 * `view_id` - The view-id is used in change-leader mode to differentiate partitioned groups while they have the same gslb namespace.
-

--- a/website/docs/d/avi_gslbgeodbprofile.html.markdown
+++ b/website/docs/d/avi_gslbgeodbprofile.html.markdown
@@ -3,7 +3,7 @@ layout: "avi"
 page_title: "AVI: avi_gslbgeodbprofile"
 sidebar_current: "docs-avi-datasource-gslbgeodbprofile"
 description: |-
-Get information of Avi GslbGeoDbProfile.
+  Get information of Avi GslbGeoDbProfile.
 ---
 
 # avi_gslbgeodbprofile
@@ -34,4 +34,3 @@ In addition to all arguments above, the following attributes are exported:
 * `name` - A user-friendly name for the geodb profile.
 * `tenant_ref` - It is a reference to an object of type tenant.
 * `uuid` - Uuid of the geodb profile.
-

--- a/website/docs/d/avi_gslbservice.html.markdown
+++ b/website/docs/d/avi_gslbservice.html.markdown
@@ -3,7 +3,7 @@ layout: "avi"
 page_title: "AVI: avi_gslbservice"
 sidebar_current: "docs-avi-datasource-gslbservice"
 description: |-
-Get information of Avi GslbService.
+  Get information of Avi GslbService.
 ---
 
 # avi_gslbservice
@@ -49,4 +49,3 @@ In addition to all arguments above, the following attributes are exported:
 * `use_edns_client_subnet` - Use the client ip subnet from the edns option as source ipaddress for client geo-location and consistent hash algorithm.
 * `uuid` - Uuid of the gslb service.
 * `wildcard_match` - Enable wild-card match of fqdn  if an exact match is not found in the dns table, the longest match is chosen by wild-carding the fqdn in the dns request.
-

--- a/website/docs/d/avi_hardwaresecuritymodulegroup.html.markdown
+++ b/website/docs/d/avi_hardwaresecuritymodulegroup.html.markdown
@@ -3,7 +3,7 @@ layout: "avi"
 page_title: "AVI: avi_hardwaresecuritymodulegroup"
 sidebar_current: "docs-avi-datasource-hardwaresecuritymodulegroup"
 description: |-
-Get information of Avi HardwareSecurityModuleGroup.
+  Get information of Avi HardwareSecurityModuleGroup.
 ---
 
 # avi_hardwaresecuritymodulegroup
@@ -32,4 +32,3 @@ In addition to all arguments above, the following attributes are exported:
 * `name` - Name of the hsm group configuration object.
 * `tenant_ref` - It is a reference to an object of type tenant.
 * `uuid` - Uuid of the hsm group configuration object.
-

--- a/website/docs/d/avi_healthmonitor.html.markdown
+++ b/website/docs/d/avi_healthmonitor.html.markdown
@@ -3,7 +3,7 @@ layout: "avi"
 page_title: "AVI: avi_healthmonitor"
 sidebar_current: "docs-avi-datasource-healthmonitor"
 description: |-
-Get information of Avi HealthMonitor.
+  Get information of Avi HealthMonitor.
 ---
 
 # avi_healthmonitor
@@ -46,4 +46,3 @@ In addition to all arguments above, the following attributes are exported:
 * `type` - Type of the health monitor.
 * `udp_monitor` - General description.
 * `uuid` - Uuid of the health monitor.
-

--- a/website/docs/d/avi_httppolicyset.html.markdown
+++ b/website/docs/d/avi_httppolicyset.html.markdown
@@ -3,7 +3,7 @@ layout: "avi"
 page_title: "AVI: avi_httppolicyset"
 sidebar_current: "docs-avi-datasource-httppolicyset"
 description: |-
-Get information of Avi HTTPPolicySet.
+  Get information of Avi HTTPPolicySet.
 ---
 
 # avi_httppolicyset
@@ -38,4 +38,3 @@ In addition to all arguments above, the following attributes are exported:
 * `name` - Name of the http policy set.
 * `tenant_ref` - It is a reference to an object of type tenant.
 * `uuid` - Uuid of the http policy set.
-

--- a/website/docs/d/avi_ipaddrgroup.html.markdown
+++ b/website/docs/d/avi_ipaddrgroup.html.markdown
@@ -3,7 +3,7 @@ layout: "avi"
 page_title: "AVI: avi_ipaddrgroup"
 sidebar_current: "docs-avi-datasource-ipaddrgroup"
 description: |-
-Get information of Avi IpAddrGroup.
+  Get information of Avi IpAddrGroup.
 ---
 
 # avi_ipaddrgroup
@@ -40,4 +40,3 @@ In addition to all arguments above, the following attributes are exported:
 * `ranges` - Configure ip address range(s).
 * `tenant_ref` - It is a reference to an object of type tenant.
 * `uuid` - Uuid of the ip address group.
-

--- a/website/docs/d/avi_ipamdnsproviderprofile.html.markdown
+++ b/website/docs/d/avi_ipamdnsproviderprofile.html.markdown
@@ -3,7 +3,7 @@ layout: "avi"
 page_title: "AVI: avi_ipamdnsproviderprofile"
 sidebar_current: "docs-avi-datasource-ipamdnsproviderprofile"
 description: |-
-Get information of Avi IpamDnsProviderProfile.
+  Get information of Avi IpamDnsProviderProfile.
 ---
 
 # avi_ipamdnsproviderprofile
@@ -42,4 +42,3 @@ In addition to all arguments above, the following attributes are exported:
 * `tenant_ref` - It is a reference to an object of type tenant.
 * `type` - Provider type for the ipam/dns provider profile.
 * `uuid` - Uuid of the ipam/dns provider profile.
-

--- a/website/docs/d/avi_l4policyset.html.markdown
+++ b/website/docs/d/avi_l4policyset.html.markdown
@@ -3,7 +3,7 @@ layout: "avi"
 page_title: "AVI: avi_l4policyset"
 sidebar_current: "docs-avi-datasource-l4policyset"
 description: |-
-Get information of Avi L4PolicySet.
+  Get information of Avi L4PolicySet.
 ---
 
 # avi_l4policyset
@@ -35,4 +35,3 @@ In addition to all arguments above, the following attributes are exported:
 * `name` - Name of the l4 policy set.
 * `tenant_ref` - It is a reference to an object of type tenant.
 * `uuid` - Id of the l4 policy set.
-

--- a/website/docs/d/avi_microservicegroup.html.markdown
+++ b/website/docs/d/avi_microservicegroup.html.markdown
@@ -3,7 +3,7 @@ layout: "avi"
 page_title: "AVI: avi_microservicegroup"
 sidebar_current: "docs-avi-datasource-microservicegroup"
 description: |-
-Get information of Avi MicroServiceGroup.
+  Get information of Avi MicroServiceGroup.
 ---
 
 # avi_microservicegroup
@@ -34,4 +34,3 @@ In addition to all arguments above, the following attributes are exported:
 * `service_refs` - Configure microservice(es).
 * `tenant_ref` - It is a reference to an object of type tenant.
 * `uuid` - Uuid of the microservice group.
-

--- a/website/docs/d/avi_network.html.markdown
+++ b/website/docs/d/avi_network.html.markdown
@@ -3,7 +3,7 @@ layout: "avi"
 page_title: "AVI: avi_network"
 sidebar_current: "docs-avi-datasource-network"
 description: |-
-Get information of Avi Network.
+  Get information of Avi Network.
 ---
 
 # avi_network
@@ -25,7 +25,7 @@ data "Network" "foo_Network" {
 * `name` - (Optional) Search Network by name.
 * `uuid` - (Optional) Search Network by uuid.
 * `cloud_ref` - (Optional) Search Network by cloud_ref.
-  
+
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
@@ -41,4 +41,3 @@ In addition to all arguments above, the following attributes are exported:
 * `uuid` - General description.
 * `vcenter_dvs` - General description.
 * `vrf_context_ref` - It is a reference to an object of type vrfcontext.
-

--- a/website/docs/d/avi_networkprofile.html.markdown
+++ b/website/docs/d/avi_networkprofile.html.markdown
@@ -3,7 +3,7 @@ layout: "avi"
 page_title: "AVI: avi_networkprofile"
 sidebar_current: "docs-avi-datasource-networkprofile"
 description: |-
-Get information of Avi NetworkProfile.
+  Get information of Avi NetworkProfile.
 ---
 
 # avi_networkprofile
@@ -34,4 +34,3 @@ In addition to all arguments above, the following attributes are exported:
 * `profile` - General description.
 * `tenant_ref` - It is a reference to an object of type tenant.
 * `uuid` - Uuid of the network profile.
-

--- a/website/docs/d/avi_networksecuritypolicy.html.markdown
+++ b/website/docs/d/avi_networksecuritypolicy.html.markdown
@@ -3,7 +3,7 @@ layout: "avi"
 page_title: "AVI: avi_networksecuritypolicy"
 sidebar_current: "docs-avi-datasource-networksecuritypolicy"
 description: |-
-Get information of Avi NetworkSecurityPolicy.
+  Get information of Avi NetworkSecurityPolicy.
 ---
 
 # avi_networksecuritypolicy
@@ -35,4 +35,3 @@ In addition to all arguments above, the following attributes are exported:
 * `rules` - General description.
 * `tenant_ref` - It is a reference to an object of type tenant.
 * `uuid` - General description.
-

--- a/website/docs/d/avi_pkiprofile.html.markdown
+++ b/website/docs/d/avi_pkiprofile.html.markdown
@@ -3,7 +3,7 @@ layout: "avi"
 page_title: "AVI: avi_pkiprofile"
 sidebar_current: "docs-avi-datasource-pkiprofile"
 description: |-
-Get information of Avi PKIProfile.
+  Get information of Avi PKIProfile.
 ---
 
 # avi_pkiprofile
@@ -38,4 +38,3 @@ In addition to all arguments above, the following attributes are exported:
 * `tenant_ref` - It is a reference to an object of type tenant.
 * `uuid` - General description.
 * `validate_only_leaf_crl` - When enabled, avi will only validate the revocation status of the leaf certificate using crl.
-

--- a/website/docs/d/avi_pool.html.markdown
+++ b/website/docs/d/avi_pool.html.markdown
@@ -3,7 +3,7 @@ layout: "avi"
 page_title: "AVI: avi_pool"
 sidebar_current: "docs-avi-datasource-pool"
 description: |-
-Get information of Avi Pool.
+  Get information of Avi Pool.
 ---
 
 # avi_pool
@@ -25,7 +25,7 @@ data "Pool" "foo_Pool" {
 * `name` - (Optional) Search Pool by name.
 * `uuid` - (Optional) Search Pool by uuid.
 * `cloud_ref` - (Optional) Search Pool by cloud_ref.
-  
+
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
@@ -81,4 +81,3 @@ In addition to all arguments above, the following attributes are exported:
 * `use_service_port` - Do not translate the client's destination port when sending the connection to the server.
 * `uuid` - Uuid of the pool.
 * `vrf_ref` - Virtual routing context that the pool is bound to.
-

--- a/website/docs/d/avi_poolgroup.html.markdown
+++ b/website/docs/d/avi_poolgroup.html.markdown
@@ -3,7 +3,7 @@ layout: "avi"
 page_title: "AVI: avi_poolgroup"
 sidebar_current: "docs-avi-datasource-poolgroup"
 description: |-
-Get information of Avi PoolGroup.
+  Get information of Avi PoolGroup.
 ---
 
 # avi_poolgroup
@@ -25,7 +25,7 @@ data "PoolGroup" "foo_PoolGroup" {
 * `name` - (Optional) Search PoolGroup by name.
 * `uuid` - (Optional) Search PoolGroup by uuid.
 * `cloud_ref` - (Optional) Search PoolGroup by cloud_ref.
-  
+
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
@@ -43,4 +43,3 @@ In addition to all arguments above, the following attributes are exported:
 * `priority_labels_ref` - Uuid of the priority labels.
 * `tenant_ref` - It is a reference to an object of type tenant.
 * `uuid` - Uuid of the pool group.
-

--- a/website/docs/d/avi_poolgroupdeploymentpolicy.html.markdown
+++ b/website/docs/d/avi_poolgroupdeploymentpolicy.html.markdown
@@ -3,7 +3,7 @@ layout: "avi"
 page_title: "AVI: avi_poolgroupdeploymentpolicy"
 sidebar_current: "docs-avi-datasource-poolgroupdeploymentpolicy"
 description: |-
-Get information of Avi PoolGroupDeploymentPolicy.
+  Get information of Avi PoolGroupDeploymentPolicy.
 ---
 
 # avi_poolgroupdeploymentpolicy
@@ -39,4 +39,3 @@ In addition to all arguments above, the following attributes are exported:
 * `test_traffic_ratio_rampup` - Ratio of the traffic that is sent to the pool under test.
 * `uuid` - Uuid of the pool group deployment policy.
 * `webhook_ref` - Webhook configured with url that avi controller will pass back information about pool group, old and new pool information and current deployment rule results.
-

--- a/website/docs/d/avi_prioritylabels.html.markdown
+++ b/website/docs/d/avi_prioritylabels.html.markdown
@@ -3,7 +3,7 @@ layout: "avi"
 page_title: "AVI: avi_prioritylabels"
 sidebar_current: "docs-avi-datasource-prioritylabels"
 description: |-
-Get information of Avi PriorityLabels.
+  Get information of Avi PriorityLabels.
 ---
 
 # avi_prioritylabels
@@ -25,7 +25,7 @@ data "PriorityLabels" "foo_PriorityLabels" {
 * `name` - (Optional) Search PriorityLabels by name.
 * `uuid` - (Optional) Search PriorityLabels by uuid.
 * `cloud_ref` - (Optional) Search PriorityLabels by cloud_ref.
-  
+
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
@@ -36,4 +36,3 @@ In addition to all arguments above, the following attributes are exported:
 * `name` - The name of the priority labels.
 * `tenant_ref` - It is a reference to an object of type tenant.
 * `uuid` - Uuid of the priority labels.
-

--- a/website/docs/d/avi_role.html.markdown
+++ b/website/docs/d/avi_role.html.markdown
@@ -3,7 +3,7 @@ layout: "avi"
 page_title: "AVI: avi_role"
 sidebar_current: "docs-avi-datasource-role"
 description: |-
-Get information of Avi Role.
+  Get information of Avi Role.
 ---
 
 # avi_role
@@ -32,4 +32,3 @@ In addition to all arguments above, the following attributes are exported:
 * `privileges` - General description.
 * `tenant_ref` - It is a reference to an object of type tenant.
 * `uuid` - General description.
-

--- a/website/docs/d/avi_scheduler.html.markdown
+++ b/website/docs/d/avi_scheduler.html.markdown
@@ -3,7 +3,7 @@ layout: "avi"
 page_title: "AVI: avi_scheduler"
 sidebar_current: "docs-avi-datasource-scheduler"
 description: |-
-Get information of Avi Scheduler.
+  Get information of Avi Scheduler.
 ---
 
 # avi_scheduler
@@ -40,4 +40,3 @@ In addition to all arguments above, the following attributes are exported:
 * `start_date_time` - Scheduler start date and time.
 * `tenant_ref` - It is a reference to an object of type tenant.
 * `uuid` - General description.
-

--- a/website/docs/d/avi_seproperties.html.markdown
+++ b/website/docs/d/avi_seproperties.html.markdown
@@ -3,7 +3,7 @@ layout: "avi"
 page_title: "AVI: avi_seproperties"
 sidebar_current: "docs-avi-datasource-seproperties"
 description: |-
-Get information of Avi SeProperties.
+  Get information of Avi SeProperties.
 ---
 
 # avi_seproperties
@@ -32,4 +32,3 @@ In addition to all arguments above, the following attributes are exported:
 * `se_bootup_properties` - General description.
 * `se_runtime_properties` - General description.
 * `uuid` - General description.
-

--- a/website/docs/d/avi_server.html.markdown
+++ b/website/docs/d/avi_server.html.markdown
@@ -3,7 +3,7 @@ layout: "avi"
 page_title: "AVI: avi_server"
 sidebar_current: "docs-avi-datasource-server"
 description: |-
-Get information of Avi Server.
+  Get information of Avi Server.
 ---
 
 # avi_server
@@ -25,14 +25,14 @@ data "avi_server" "foo_Server" {
 * `pool_ref` - (Optional) Search Server by pool_ref.
 * `uuid` - (Optional) Search Server by uuid.
 * `ip` - (Optional) Search Server by ip.
-  
+
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
 
 * `uuid` - (Optional) Search server object by uuid.
 * `pool_ref` - The pool is an object that contains destination servers and related attributes such as load-balancing and persistence.
-* `ip` - IP address of a destination servers. 
+* `ip` - IP address of a destination servers.
 * `port` - Port of a destination servers.
 * `type` - Type of ip address (V4)
 * `autoscaling_group_name` - Name of autoscaling group this server belongs to.
@@ -42,7 +42,7 @@ In addition to all arguments above, the following attributes are exported:
 * `external_uuid` - UUID identifying VM in OpenStack and other external compute.
 * `hostname` - DNS resolvable name of the server. May be used in place of the IP address.
 * `location` - Geographic location of the server.Currently only for internal usage.
-* `nw_ref` - This field is used internally by Avi, not editable by the user. It is a reference to an object of type VIMgrNWRuntime. 
-* `prst_hdr_val` - Header value for custom header persistence. 
+* `nw_ref` - This field is used internally by Avi, not editable by the user. It is a reference to an object of type VIMgrNWRuntime.
+* `prst_hdr_val` - Header value for custom header persistence.
 * `rewrite_host_header` - Rewrite incoming Host Header to server name.
 * `vm_ref` - This field is used internally by Avi, not editable by the user. It is a reference to an object of type VIMgrVMRuntime.

--- a/website/docs/d/avi_serverautoscalepolicy.html.markdown
+++ b/website/docs/d/avi_serverautoscalepolicy.html.markdown
@@ -3,7 +3,7 @@ layout: "avi"
 page_title: "AVI: avi_serverautoscalepolicy"
 sidebar_current: "docs-avi-datasource-serverautoscalepolicy"
 description: |-
-Get information of Avi ServerAutoScalePolicy.
+  Get information of Avi ServerAutoScalePolicy.
 ---
 
 # avi_serverautoscalepolicy
@@ -44,4 +44,3 @@ In addition to all arguments above, the following attributes are exported:
 * `tenant_ref` - It is a reference to an object of type tenant.
 * `use_predicted_load` - Use predicted load rather than current load.
 * `uuid` - General description.
-

--- a/website/docs/d/avi_serviceengine.html.markdown
+++ b/website/docs/d/avi_serviceengine.html.markdown
@@ -3,7 +3,7 @@ layout: "avi"
 page_title: "AVI: avi_serviceengine"
 sidebar_current: "docs-avi-datasource-serviceengine"
 description: |-
-Get information of Avi ServiceEngine.
+  Get information of Avi ServiceEngine.
 ---
 
 # avi_serviceengine
@@ -25,7 +25,7 @@ data "ServiceEngine" "foo_ServiceEngine" {
 * `name` - (Optional) Search ServiceEngine by name.
 * `uuid` - (Optional) Search ServiceEngine by uuid.
 * `cloud_ref` - (Optional) Search ServiceEngine by cloud_ref.
-  
+
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
@@ -47,4 +47,3 @@ In addition to all arguments above, the following attributes are exported:
 * `se_group_ref` - It is a reference to an object of type serviceenginegroup.
 * `tenant_ref` - It is a reference to an object of type tenant.
 * `uuid` - General description.
-

--- a/website/docs/d/avi_serviceenginegroup.html.markdown
+++ b/website/docs/d/avi_serviceenginegroup.html.markdown
@@ -3,7 +3,7 @@ layout: "avi"
 page_title: "AVI: avi_serviceenginegroup"
 sidebar_current: "docs-avi-datasource-serviceenginegroup"
 description: |-
-Get information of Avi ServiceEngineGroup.
+  Get information of Avi ServiceEngineGroup.
 ---
 
 # avi_serviceenginegroup
@@ -25,7 +25,7 @@ data "ServiceEngineGroup" "foo_ServiceEngineGroup" {
 * `name` - (Optional) Search ServiceEngineGroup by name.
 * `uuid` - (Optional) Search ServiceEngineGroup by uuid.
 * `cloud_ref` - (Optional) Search ServiceEngineGroup by cloud_ref.
-  
+
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
@@ -163,4 +163,3 @@ In addition to all arguments above, the following attributes are exported:
 * `waf_learning_memory` - Amount of memory reserved on se for waf learning.
 * `waf_mempool` - Enable memory pool for waf.
 * `waf_mempool_size` - Memory pool size used for waf.
-

--- a/website/docs/d/avi_snmptrapprofile.html.markdown
+++ b/website/docs/d/avi_snmptrapprofile.html.markdown
@@ -3,7 +3,7 @@ layout: "avi"
 page_title: "AVI: avi_snmptrapprofile"
 sidebar_current: "docs-avi-datasource-snmptrapprofile"
 description: |-
-Get information of Avi SnmpTrapProfile.
+  Get information of Avi SnmpTrapProfile.
 ---
 
 # avi_snmptrapprofile
@@ -32,4 +32,3 @@ In addition to all arguments above, the following attributes are exported:
 * `tenant_ref` - It is a reference to an object of type tenant.
 * `trap_servers` - The ip address or hostname of the snmp trap destination server.
 * `uuid` - Uuid of the snmp trap profile object.
-

--- a/website/docs/d/avi_sslkeyandcertificate.html.markdown
+++ b/website/docs/d/avi_sslkeyandcertificate.html.markdown
@@ -3,7 +3,7 @@ layout: "avi"
 page_title: "AVI: avi_sslkeyandcertificate"
 sidebar_current: "docs-avi-datasource-sslkeyandcertificate"
 description: |-
-Get information of Avi SSLKeyAndCertificate.
+  Get information of Avi SSLKeyAndCertificate.
 ---
 
 # avi_sslkeyandcertificate
@@ -47,4 +47,3 @@ In addition to all arguments above, the following attributes are exported:
 * `tenant_ref` - It is a reference to an object of type tenant.
 * `type` - Enum options - ssl_certificate_type_virtualservice, ssl_certificate_type_system, ssl_certificate_type_ca.
 * `uuid` - General description.
-

--- a/website/docs/d/avi_sslprofile.html.markdown
+++ b/website/docs/d/avi_sslprofile.html.markdown
@@ -3,7 +3,7 @@ layout: "avi"
 page_title: "AVI: avi_sslprofile"
 sidebar_current: "docs-avi-datasource-sslprofile"
 description: |-
-Get information of Avi SSLProfile.
+  Get information of Avi SSLProfile.
 ---
 
 # avi_sslprofile
@@ -43,4 +43,3 @@ In addition to all arguments above, the following attributes are exported:
 * `tenant_ref` - It is a reference to an object of type tenant.
 * `type` - Ssl profile type.
 * `uuid` - General description.
-

--- a/website/docs/d/avi_stringgroup.html.markdown
+++ b/website/docs/d/avi_stringgroup.html.markdown
@@ -3,7 +3,7 @@ layout: "avi"
 page_title: "AVI: avi_stringgroup"
 sidebar_current: "docs-avi-datasource-stringgroup"
 description: |-
-Get information of Avi StringGroup.
+  Get information of Avi StringGroup.
 ---
 
 # avi_stringgroup
@@ -34,4 +34,3 @@ In addition to all arguments above, the following attributes are exported:
 * `tenant_ref` - It is a reference to an object of type tenant.
 * `type` - Type of stringgroup.
 * `uuid` - Uuid of the string group.
-

--- a/website/docs/d/avi_systemconfiguration.html.markdown
+++ b/website/docs/d/avi_systemconfiguration.html.markdown
@@ -3,7 +3,7 @@ layout: "avi"
 page_title: "AVI: avi_systemconfiguration"
 sidebar_current: "docs-avi-datasource-systemconfiguration"
 description: |-
-Get information of Avi SystemConfiguration.
+  Get information of Avi SystemConfiguration.
 ---
 
 # avi_systemconfiguration
@@ -44,4 +44,3 @@ In addition to all arguments above, the following attributes are exported:
 * `ssh_ciphers` - Allowed ciphers list for ssh to the management interface on the controller and service engines.
 * `ssh_hmacs` - Allowed hmac list for ssh to the management interface on the controller and service engines.
 * `uuid` - General description.
-

--- a/website/docs/d/avi_tenant.html.markdown
+++ b/website/docs/d/avi_tenant.html.markdown
@@ -3,7 +3,7 @@ layout: "avi"
 page_title: "AVI: avi_tenant"
 sidebar_current: "docs-avi-datasource-tenant"
 description: |-
-Get information of Avi Tenant.
+  Get information of Avi Tenant.
 ---
 
 # avi_tenant
@@ -34,4 +34,3 @@ In addition to all arguments above, the following attributes are exported:
 * `local` - General description.
 * `name` - General description.
 * `uuid` - General description.
-

--- a/website/docs/d/avi_trafficcloneprofile.html.markdown
+++ b/website/docs/d/avi_trafficcloneprofile.html.markdown
@@ -3,7 +3,7 @@ layout: "avi"
 page_title: "AVI: avi_trafficcloneprofile"
 sidebar_current: "docs-avi-datasource-trafficcloneprofile"
 description: |-
-Get information of Avi TrafficCloneProfile.
+  Get information of Avi TrafficCloneProfile.
 ---
 
 # avi_trafficcloneprofile
@@ -25,7 +25,7 @@ data "TrafficCloneProfile" "foo_TrafficCloneProfile" {
 * `name` - (Optional) Search TrafficCloneProfile by name.
 * `uuid` - (Optional) Search TrafficCloneProfile by uuid.
 * `cloud_ref` - (Optional) Search TrafficCloneProfile by cloud_ref.
-  
+
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
@@ -36,4 +36,3 @@ In addition to all arguments above, the following attributes are exported:
 * `preserve_client_ip` - Specifies if client ip needs to be preserved to clone destination.
 * `tenant_ref` - It is a reference to an object of type tenant.
 * `uuid` - Uuid of the traffic clone profile.
-

--- a/website/docs/d/avi_useraccountprofile.html.markdown
+++ b/website/docs/d/avi_useraccountprofile.html.markdown
@@ -3,7 +3,7 @@ layout: "avi"
 page_title: "AVI: avi_useraccountprofile"
 sidebar_current: "docs-avi-datasource-useraccountprofile"
 description: |-
-Get information of Avi UserAccountProfile.
+  Get information of Avi UserAccountProfile.
 ---
 
 # avi_useraccountprofile
@@ -35,4 +35,3 @@ In addition to all arguments above, the following attributes are exported:
 * `max_password_history_count` - Maximum number of passwords to be maintained in the password history.
 * `name` - General description.
 * `uuid` - General description.
-

--- a/website/docs/d/avi_virtualservice.html.markdown
+++ b/website/docs/d/avi_virtualservice.html.markdown
@@ -3,7 +3,7 @@ layout: "avi"
 page_title: "AVI: avi_virtualservice"
 sidebar_current: "docs-avi-datasource-virtualservice"
 description: |-
-Get information of Avi VirtualService.
+  Get information of Avi VirtualService.
 ---
 
 # avi_virtualservice
@@ -25,7 +25,7 @@ data "VirtualService" "foo_VirtualService" {
 * `name` - (Optional) Search VirtualService by name.
 * `uuid` - (Optional) Search VirtualService by uuid.
 * `cloud_ref` - (Optional) Search VirtualService by cloud_ref.
-  
+
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
@@ -101,4 +101,3 @@ In addition to all arguments above, the following attributes are exported:
 * `vsvip_ref` - Mostly used during the creation of shared vs, this field refers to entities that can be shared across virtual services.
 * `waf_policy_ref` - Waf policy for the virtual service.
 * `weight` - The quality of service weight to assign to traffic transmitted from this virtual service.
-

--- a/website/docs/d/avi_vrfcontext.html.markdown
+++ b/website/docs/d/avi_vrfcontext.html.markdown
@@ -3,7 +3,7 @@ layout: "avi"
 page_title: "AVI: avi_vrfcontext"
 sidebar_current: "docs-avi-datasource-vrfcontext"
 description: |-
-Get information of Avi VrfContext.
+  Get information of Avi VrfContext.
 ---
 
 # avi_vrfcontext
@@ -25,7 +25,7 @@ data "VrfContext" "foo_VrfContext" {
 * `name` - (Optional) Search VrfContext by name.
 * `uuid` - (Optional) Search VrfContext by uuid.
 * `cloud_ref` - (Optional) Search VrfContext by cloud_ref.
-  
+
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
@@ -41,4 +41,3 @@ In addition to all arguments above, the following attributes are exported:
 * `system_default` - General description.
 * `tenant_ref` - It is a reference to an object of type tenant.
 * `uuid` - General description.
-

--- a/website/docs/d/avi_vsdatascriptset.html.markdown
+++ b/website/docs/d/avi_vsdatascriptset.html.markdown
@@ -3,7 +3,7 @@ layout: "avi"
 page_title: "AVI: avi_vsdatascriptset"
 sidebar_current: "docs-avi-datasource-vsdatascriptset"
 description: |-
-Get information of Avi VSDataScriptSet.
+  Get information of Avi VSDataScriptSet.
 ---
 
 # avi_vsdatascriptset
@@ -38,4 +38,3 @@ In addition to all arguments above, the following attributes are exported:
 * `string_group_refs` - Uuid of string groups that could be referred by vsdatascriptset objects.
 * `tenant_ref` - It is a reference to an object of type tenant.
 * `uuid` - Uuid of the virtual service datascript collection.
-

--- a/website/docs/d/avi_vsvip.html.markdown
+++ b/website/docs/d/avi_vsvip.html.markdown
@@ -3,7 +3,7 @@ layout: "avi"
 page_title: "AVI: avi_vsvip"
 sidebar_current: "docs-avi-datasource-vsvip"
 description: |-
-Get information of Avi VsVip.
+  Get information of Avi VsVip.
 ---
 
 # avi_vsvip
@@ -25,7 +25,7 @@ data "VsVip" "foo_VsVip" {
 * `name` - (Optional) Search VsVip by name.
 * `uuid` - (Optional) Search VsVip by uuid.
 * `cloud_ref` - (Optional) Search VsVip by cloud_ref.
-  
+
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
@@ -39,4 +39,3 @@ In addition to all arguments above, the following attributes are exported:
 * `vip` - List of virtual service ips and other shareable entities.
 * `vrf_context_ref` - Virtual routing context that the virtual service is bound to.
 * `vsvip_cloud_config_cksum` - Checksum of cloud configuration for vsvip.
-

--- a/website/docs/d/avi_wafpolicy.html.markdown
+++ b/website/docs/d/avi_wafpolicy.html.markdown
@@ -3,7 +3,7 @@ layout: "avi"
 page_title: "AVI: avi_wafpolicy"
 sidebar_current: "docs-avi-datasource-wafpolicy"
 description: |-
-Get information of Avi WafPolicy.
+  Get information of Avi WafPolicy.
 ---
 
 # avi_wafpolicy
@@ -42,4 +42,3 @@ In addition to all arguments above, the following attributes are exported:
 * `uuid` - Field introduced in 17.2.1.
 * `waf_crs_ref` - Waf core ruleset used for the crs part of this policy.
 * `waf_profile_ref` - Waf profile for waf policy.
-

--- a/website/docs/d/avi_wafprofile.html.markdown
+++ b/website/docs/d/avi_wafprofile.html.markdown
@@ -3,7 +3,7 @@ layout: "avi"
 page_title: "AVI: avi_wafprofile"
 sidebar_current: "docs-avi-datasource-wafprofile"
 description: |-
-Get information of Avi WafProfile.
+  Get information of Avi WafProfile.
 ---
 
 # avi_wafprofile
@@ -34,4 +34,3 @@ In addition to all arguments above, the following attributes are exported:
 * `name` - Field introduced in 17.2.1.
 * `tenant_ref` - It is a reference to an object of type tenant.
 * `uuid` - Field introduced in 17.2.1.
-

--- a/website/docs/d/avi_webhook.html.markdown
+++ b/website/docs/d/avi_webhook.html.markdown
@@ -3,7 +3,7 @@ layout: "avi"
 page_title: "AVI: avi_webhook"
 sidebar_current: "docs-avi-datasource-webhook"
 description: |-
-Get information of Avi Webhook.
+  Get information of Avi Webhook.
 ---
 
 # avi_webhook
@@ -34,4 +34,3 @@ In addition to all arguments above, the following attributes are exported:
 * `tenant_ref` - It is a reference to an object of type tenant.
 * `uuid` - Uuid of the webhook profile.
 * `verification_token` - Verification token sent back with the callback asquery parameters.
-

--- a/website/docs/r/avi_actiongroupconfig.html.markdown
+++ b/website/docs/r/avi_actiongroupconfig.html.markdown
@@ -3,7 +3,7 @@ layout: "avi"
 page_title: "Avi: avi_actiongroupconfig"
 sidebar_current: "docs-avi-resource-actiongroupconfig"
 description: |-
-Creates and manages Avi ActionGroupConfig.
+  Creates and manages Avi ActionGroupConfig.
 ---
 
 # avi_actiongroupconfig
@@ -33,7 +33,7 @@ The following arguments are supported:
         * `snmp_trap_profile_ref` - (Optional ) argument_description.
         * `syslog_config_ref` - (Optional ) argument_description.
         * `tenant_ref` - (Optional ) argument_description.
-        
+
 ### Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
@@ -47,4 +47,3 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/d
 In addition to all arguments above, the following attributes are exported:
 
                                             * `uuid` - argument_description.
-    

--- a/website/docs/r/avi_alertconfig.html.markdown
+++ b/website/docs/r/avi_alertconfig.html.markdown
@@ -3,7 +3,7 @@ layout: "avi"
 page_title: "Avi: avi_alertconfig"
 sidebar_current: "docs-avi-resource-alertconfig"
 description: |-
-Creates and manages Avi AlertConfig.
+  Creates and manages Avi AlertConfig.
 ---
 
 # avi_alertconfig
@@ -40,7 +40,7 @@ The following arguments are supported:
         * `tenant_ref` - (Optional ) argument_description.
         * `threshold` - (Optional ) argument_description.
         * `throttle` - (Optional ) argument_description.
-        
+
 ### Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
@@ -54,4 +54,3 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/d
 In addition to all arguments above, the following attributes are exported:
 
                                                                         * `uuid` - argument_description.
-    

--- a/website/docs/r/avi_alertemailconfig.html.markdown
+++ b/website/docs/r/avi_alertemailconfig.html.markdown
@@ -3,7 +3,7 @@ layout: "avi"
 page_title: "Avi: avi_alertemailconfig"
 sidebar_current: "docs-avi-resource-alertemailconfig"
 description: |-
-Creates and manages Avi AlertEmailConfig.
+  Creates and manages Avi AlertEmailConfig.
 ---
 
 # avi_alertemailconfig
@@ -28,7 +28,7 @@ The following arguments are supported:
         * `name` - (Required) argument_description.
         * `tenant_ref` - (Optional ) argument_description.
         * `to_emails` - (Required) argument_description.
-        
+
 ### Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
@@ -42,4 +42,3 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/d
 In addition to all arguments above, the following attributes are exported:
 
                         * `uuid` - argument_description.
-    

--- a/website/docs/r/avi_alertscriptconfig.html.markdown
+++ b/website/docs/r/avi_alertscriptconfig.html.markdown
@@ -3,7 +3,7 @@ layout: "avi"
 page_title: "Avi: avi_alertscriptconfig"
 sidebar_current: "docs-avi-resource-alertscriptconfig"
 description: |-
-Creates and manages Avi AlertScriptConfig.
+  Creates and manages Avi AlertScriptConfig.
 ---
 
 # avi_alertscriptconfig
@@ -26,7 +26,7 @@ The following arguments are supported:
     * `action_script` - (Optional ) argument_description.
         * `name` - (Required) argument_description.
         * `tenant_ref` - (Optional ) argument_description.
-        
+
 ### Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
@@ -40,4 +40,3 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/d
 In addition to all arguments above, the following attributes are exported:
 
                 * `uuid` - argument_description.
-    

--- a/website/docs/r/avi_alertsyslogconfig.html.markdown
+++ b/website/docs/r/avi_alertsyslogconfig.html.markdown
@@ -3,7 +3,7 @@ layout: "avi"
 page_title: "Avi: avi_alertsyslogconfig"
 sidebar_current: "docs-avi-resource-alertsyslogconfig"
 description: |-
-Creates and manages Avi AlertSyslogConfig.
+  Creates and manages Avi AlertSyslogConfig.
 ---
 
 # avi_alertsyslogconfig
@@ -27,7 +27,7 @@ The following arguments are supported:
         * `name` - (Required) argument_description.
         * `syslog_servers` - (Optional ) argument_description.
         * `tenant_ref` - (Optional ) argument_description.
-        
+
 ### Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
@@ -41,4 +41,3 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/d
 In addition to all arguments above, the following attributes are exported:
 
                     * `uuid` - argument_description.
-    

--- a/website/docs/r/avi_analyticsprofile.html.markdown
+++ b/website/docs/r/avi_analyticsprofile.html.markdown
@@ -3,7 +3,7 @@ layout: "avi"
 page_title: "Avi: avi_analyticsprofile"
 sidebar_current: "docs-avi-resource-analyticsprofile"
 description: |-
-Creates and manages Avi AnalyticsProfile.
+  Creates and manages Avi AnalyticsProfile.
 ---
 
 # avi_analyticsprofile
@@ -93,7 +93,7 @@ The following arguments are supported:
         * `resp_code_block` - (Optional ) argument_description.
         * `sensitive_log_profile` - (Optional ) argument_description.
         * `tenant_ref` - (Optional ) argument_description.
-        
+
 ### Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
@@ -107,4 +107,3 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/d
 In addition to all arguments above, the following attributes are exported:
 
                                                                                                                                                                                                                                                                                             * `uuid` - argument_description.
-    

--- a/website/docs/r/avi_applicationpersistenceprofile.html.markdown
+++ b/website/docs/r/avi_applicationpersistenceprofile.html.markdown
@@ -3,7 +3,7 @@ layout: "avi"
 page_title: "Avi: avi_applicationpersistenceprofile"
 sidebar_current: "docs-avi-resource-applicationpersistenceprofile"
 description: |-
-Creates and manages Avi ApplicationPersistenceProfile.
+  Creates and manages Avi ApplicationPersistenceProfile.
 ---
 
 # avi_applicationpersistenceprofile
@@ -33,7 +33,7 @@ The following arguments are supported:
         * `persistence_type` - (Required) argument_description.
         * `server_hm_down_recovery` - (Optional ) argument_description.
         * `tenant_ref` - (Optional ) argument_description.
-        
+
 ### Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
@@ -47,4 +47,3 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/d
 In addition to all arguments above, the following attributes are exported:
 
                                             * `uuid` - argument_description.
-    

--- a/website/docs/r/avi_applicationprofile.html.markdown
+++ b/website/docs/r/avi_applicationprofile.html.markdown
@@ -3,7 +3,7 @@ layout: "avi"
 page_title: "Avi: avi_applicationprofile"
 sidebar_current: "docs-avi-resource-applicationprofile"
 description: |-
-Creates and manages Avi ApplicationProfile.
+  Creates and manages Avi ApplicationProfile.
 ---
 
 # avi_applicationprofile
@@ -34,7 +34,7 @@ The following arguments are supported:
         * `tcp_app_profile` - (Optional ) argument_description.
         * `tenant_ref` - (Optional ) argument_description.
         * `type` - (Required) argument_description.
-        
+
 ### Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
@@ -48,4 +48,3 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/d
 In addition to all arguments above, the following attributes are exported:
 
                                                 * `uuid` - argument_description.
-    

--- a/website/docs/r/avi_authprofile.html.markdown
+++ b/website/docs/r/avi_authprofile.html.markdown
@@ -3,7 +3,7 @@ layout: "avi"
 page_title: "Avi: avi_authprofile"
 sidebar_current: "docs-avi-resource-authprofile"
 description: |-
-Creates and manages Avi AuthProfile.
+  Creates and manages Avi AuthProfile.
 ---
 
 # avi_authprofile
@@ -31,7 +31,7 @@ The following arguments are supported:
         * `tacacs_plus` - (Optional ) argument_description.
         * `tenant_ref` - (Optional ) argument_description.
         * `type` - (Required) argument_description.
-        
+
 ### Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
@@ -45,4 +45,3 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/d
 In addition to all arguments above, the following attributes are exported:
 
                                     * `uuid` - argument_description.
-    

--- a/website/docs/r/avi_autoscalelaunchconfig.html.markdown
+++ b/website/docs/r/avi_autoscalelaunchconfig.html.markdown
@@ -3,7 +3,7 @@ layout: "avi"
 page_title: "Avi: avi_autoscalelaunchconfig"
 sidebar_current: "docs-avi-resource-autoscalelaunchconfig"
 description: |-
-Creates and manages Avi AutoScaleLaunchConfig.
+  Creates and manages Avi AutoScaleLaunchConfig.
 ---
 
 # avi_autoscalelaunchconfig
@@ -30,7 +30,7 @@ The following arguments are supported:
         * `openstack` - (Optional ) argument_description.
         * `tenant_ref` - (Optional ) argument_description.
         * `use_external_asg` - (Optional ) argument_description.
-        
+
 ### Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
@@ -44,4 +44,3 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/d
 In addition to all arguments above, the following attributes are exported:
 
                                 * `uuid` - argument_description.
-    

--- a/website/docs/r/avi_backup.html.markdown
+++ b/website/docs/r/avi_backup.html.markdown
@@ -3,7 +3,7 @@ layout: "avi"
 page_title: "Avi: avi_backup"
 sidebar_current: "docs-avi-resource-backup"
 description: |-
-Creates and manages Avi Backup.
+  Creates and manages Avi Backup.
 ---
 
 # avi_backup
@@ -30,7 +30,7 @@ The following arguments are supported:
         * `scheduler_ref` - (Optional ) argument_description.
         * `tenant_ref` - (Optional ) argument_description.
         * `timestamp` - (Optional ) argument_description.
-        
+
 ### Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
@@ -44,4 +44,3 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/d
 In addition to all arguments above, the following attributes are exported:
 
                                 * `uuid` - argument_description.
-    

--- a/website/docs/r/avi_backupconfiguration.html.markdown
+++ b/website/docs/r/avi_backupconfiguration.html.markdown
@@ -3,7 +3,7 @@ layout: "avi"
 page_title: "Avi: avi_backupconfiguration"
 sidebar_current: "docs-avi-resource-backupconfiguration"
 description: |-
-Creates and manages Avi BackupConfiguration.
+  Creates and manages Avi BackupConfiguration.
 ---
 
 # avi_backupconfiguration
@@ -33,7 +33,7 @@ The following arguments are supported:
         * `ssh_user_ref` - (Optional ) argument_description.
         * `tenant_ref` - (Optional ) argument_description.
         * `upload_to_remote_host` - (Optional ) argument_description.
-        
+
 ### Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
@@ -47,4 +47,3 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/d
 In addition to all arguments above, the following attributes are exported:
 
                                             * `uuid` - argument_description.
-    

--- a/website/docs/r/avi_certificatemanagementprofile.html.markdown
+++ b/website/docs/r/avi_certificatemanagementprofile.html.markdown
@@ -3,7 +3,7 @@ layout: "avi"
 page_title: "Avi: avi_certificatemanagementprofile"
 sidebar_current: "docs-avi-resource-certificatemanagementprofile"
 description: |-
-Creates and manages Avi CertificateManagementProfile.
+  Creates and manages Avi CertificateManagementProfile.
 ---
 
 # avi_certificatemanagementprofile
@@ -27,7 +27,7 @@ The following arguments are supported:
         * `script_params` - (Optional ) argument_description.
         * `script_path` - (Required) argument_description.
         * `tenant_ref` - (Optional ) argument_description.
-        
+
 ### Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
@@ -41,4 +41,3 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/d
 In addition to all arguments above, the following attributes are exported:
 
                     * `uuid` - argument_description.
-    

--- a/website/docs/r/avi_cloud.html.markdown
+++ b/website/docs/r/avi_cloud.html.markdown
@@ -3,7 +3,7 @@ layout: "avi"
 page_title: "Avi: avi_cloud"
 sidebar_current: "docs-avi-resource-cloud"
 description: |-
-Creates and manages Avi Cloud.
+  Creates and manages Avi Cloud.
 ---
 
 # avi_cloud
@@ -55,7 +55,7 @@ The following arguments are supported:
             * `vca_configuration` - (Optional ) argument_description.
         * `vcenter_configuration` - (Optional ) argument_description.
         * `vtype` - (Required) argument_description.
-    
+
 ### Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
@@ -69,4 +69,3 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/d
 In addition to all arguments above, the following attributes are exported:
 
                                                                                                                         * `uuid` - argument_description.
-                

--- a/website/docs/r/avi_cloudconnectoruser.html.markdown
+++ b/website/docs/r/avi_cloudconnectoruser.html.markdown
@@ -3,7 +3,7 @@ layout: "avi"
 page_title: "Avi: avi_cloudconnectoruser"
 sidebar_current: "docs-avi-resource-cloudconnectoruser"
 description: |-
-Creates and manages Avi CloudConnectorUser.
+  Creates and manages Avi CloudConnectorUser.
 ---
 
 # avi_cloudconnectoruser
@@ -31,7 +31,7 @@ The following arguments are supported:
         * `private_key` - (Optional ) argument_description.
         * `public_key` - (Optional ) argument_description.
         * `tenant_ref` - (Optional ) argument_description.
-        
+
 ### Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
@@ -45,4 +45,3 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/d
 In addition to all arguments above, the following attributes are exported:
 
                                     * `uuid` - argument_description.
-    

--- a/website/docs/r/avi_cloudproperties.html.markdown
+++ b/website/docs/r/avi_cloudproperties.html.markdown
@@ -3,7 +3,7 @@ layout: "avi"
 page_title: "Avi: avi_cloudproperties"
 sidebar_current: "docs-avi-resource-cloudproperties"
 description: |-
-Creates and manages Avi CloudProperties.
+  Creates and manages Avi CloudProperties.
 ---
 
 # avi_cloudproperties
@@ -27,7 +27,7 @@ The following arguments are supported:
         * `cc_vtypes` - (Optional ) argument_description.
         * `hyp_props` - (Optional ) argument_description.
         * `info` - (Optional ) argument_description.
-        
+
 ### Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
@@ -41,4 +41,3 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/d
 In addition to all arguments above, the following attributes are exported:
 
                     * `uuid` - argument_description.
-    

--- a/website/docs/r/avi_cluster.html.markdown
+++ b/website/docs/r/avi_cluster.html.markdown
@@ -3,7 +3,7 @@ layout: "avi"
 page_title: "Avi: avi_cluster"
 sidebar_current: "docs-avi-resource-cluster"
 description: |-
-Creates and manages Avi Cluster.
+  Creates and manages Avi Cluster.
 ---
 
 # avi_cluster
@@ -28,7 +28,7 @@ The following arguments are supported:
         * `rejoin_nodes_automatically` - (Optional ) argument_description.
         * `tenant_ref` - (Optional ) argument_description.
             * `virtual_ip` - (Optional ) argument_description.
-    
+
 ### Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
@@ -42,4 +42,3 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/d
 In addition to all arguments above, the following attributes are exported:
 
                     * `uuid` - argument_description.
-        

--- a/website/docs/r/avi_clusterclouddetails.html.markdown
+++ b/website/docs/r/avi_clusterclouddetails.html.markdown
@@ -3,7 +3,7 @@ layout: "avi"
 page_title: "Avi: avi_clusterclouddetails"
 sidebar_current: "docs-avi-resource-clusterclouddetails"
 description: |-
-Creates and manages Avi ClusterCloudDetails.
+  Creates and manages Avi ClusterCloudDetails.
 ---
 
 # avi_clusterclouddetails
@@ -26,7 +26,7 @@ The following arguments are supported:
     * `azure_info` - (Optional ) argument_description.
         * `name` - (Required) argument_description.
         * `tenant_ref` - (Optional ) argument_description.
-        
+
 ### Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
@@ -40,4 +40,3 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/d
 In addition to all arguments above, the following attributes are exported:
 
                 * `uuid` - argument_description.
-    

--- a/website/docs/r/avi_controllerproperties.html.markdown
+++ b/website/docs/r/avi_controllerproperties.html.markdown
@@ -3,7 +3,7 @@ layout: "avi"
 page_title: "Avi: avi_controllerproperties"
 sidebar_current: "docs-avi-resource-controllerproperties"
 description: |-
-Creates and manages Avi ControllerProperties.
+  Creates and manages Avi ControllerProperties.
 ---
 
 # avi_controllerproperties
@@ -78,7 +78,7 @@ The following arguments are supported:
         * `vs_se_vnic_ip_fail` - (Optional ) argument_description.
         * `warmstart_se_reconnect_wait_time` - (Optional ) argument_description.
         * `warmstart_vs_resync_wait_time` - (Optional ) argument_description.
-    
+
 ### Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
@@ -92,4 +92,3 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/d
 In addition to all arguments above, the following attributes are exported:
 
                                                                                                                                                                                 * `uuid` - argument_description.
-                                                    

--- a/website/docs/r/avi_customipamdnsprofile.html.markdown
+++ b/website/docs/r/avi_customipamdnsprofile.html.markdown
@@ -3,7 +3,7 @@ layout: "avi"
 page_title: "Avi: avi_customipamdnsprofile"
 sidebar_current: "docs-avi-resource-customipamdnsprofile"
 description: |-
-Creates and manages Avi CustomIpamDnsProfile.
+  Creates and manages Avi CustomIpamDnsProfile.
 ---
 
 # avi_customipamdnsprofile
@@ -27,7 +27,7 @@ The following arguments are supported:
         * `script_params` - (Optional ) argument_description.
         * `script_uri` - (Optional ) argument_description.
         * `tenant_ref` - (Optional ) argument_description.
-        
+
 ### Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
@@ -41,4 +41,3 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/d
 In addition to all arguments above, the following attributes are exported:
 
                     * `uuid` - argument_description.
-    

--- a/website/docs/r/avi_dnspolicy.html.markdown
+++ b/website/docs/r/avi_dnspolicy.html.markdown
@@ -3,7 +3,7 @@ layout: "avi"
 page_title: "Avi: avi_dnspolicy"
 sidebar_current: "docs-avi-resource-dnspolicy"
 description: |-
-Creates and manages Avi DnsPolicy.
+  Creates and manages Avi DnsPolicy.
 ---
 
 # avi_dnspolicy
@@ -28,7 +28,7 @@ The following arguments are supported:
         * `name` - (Optional ) argument_description.
         * `rule` - (Optional ) argument_description.
         * `tenant_ref` - (Optional ) argument_description.
-        
+
 ### Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
@@ -42,4 +42,3 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/d
 In addition to all arguments above, the following attributes are exported:
 
                         * `uuid` - argument_description.
-    

--- a/website/docs/r/avi_errorpagebody.html.markdown
+++ b/website/docs/r/avi_errorpagebody.html.markdown
@@ -3,7 +3,7 @@ layout: "avi"
 page_title: "Avi: avi_errorpagebody"
 sidebar_current: "docs-avi-resource-errorpagebody"
 description: |-
-Creates and manages Avi ErrorPageBody.
+  Creates and manages Avi ErrorPageBody.
 ---
 
 # avi_errorpagebody
@@ -26,7 +26,7 @@ The following arguments are supported:
     * `error_page_body` - (Optional ) argument_description.
         * `name` - (Optional ) argument_description.
         * `tenant_ref` - (Optional ) argument_description.
-        
+
 ### Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
@@ -40,4 +40,3 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/d
 In addition to all arguments above, the following attributes are exported:
 
                 * `uuid` - argument_description.
-    

--- a/website/docs/r/avi_errorpageprofile.html.markdown
+++ b/website/docs/r/avi_errorpageprofile.html.markdown
@@ -3,7 +3,7 @@ layout: "avi"
 page_title: "Avi: avi_errorpageprofile"
 sidebar_current: "docs-avi-resource-errorpageprofile"
 description: |-
-Creates and manages Avi ErrorPageProfile.
+  Creates and manages Avi ErrorPageProfile.
 ---
 
 # avi_errorpageprofile
@@ -26,7 +26,7 @@ The following arguments are supported:
     * `error_pages` - (Optional ) argument_description.
         * `name` - (Optional ) argument_description.
         * `tenant_ref` - (Optional ) argument_description.
-        
+
 ### Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
@@ -40,4 +40,3 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/d
 In addition to all arguments above, the following attributes are exported:
 
                 * `uuid` - argument_description.
-    

--- a/website/docs/r/avi_fileservice.html.markdown
+++ b/website/docs/r/avi_fileservice.html.markdown
@@ -3,7 +3,7 @@ layout: "avi"
 page_title: "Avi: avi_fileservice"
 sidebar_current: "docs-avi-resource-fileservice"
 description: |-
-Upload and Download files.
+  Upload and Download files.
 ---
 
 # avi_fileservice
@@ -27,8 +27,8 @@ The following arguments are supported:
     * `uri` - (Required) argument_description.
     * `local_file` - (Required) argument_description.
     * `upload` - (Optional ) argument_description.
-    
-    
+
+
 ### Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
@@ -39,8 +39,7 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/d
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
-                        
+
     * `uuid` - argument_description.
 
                                                                                                                                                                                                                                                         * `uuid` - argument_description.
-                                        

--- a/website/docs/r/avi_gslb.html.markdown
+++ b/website/docs/r/avi_gslb.html.markdown
@@ -3,7 +3,7 @@ layout: "avi"
 page_title: "Avi: avi_gslb"
 sidebar_current: "docs-avi-resource-gslb"
 description: |-
-Creates and manages Avi Gslb.
+  Creates and manages Avi Gslb.
 ---
 
 # avi_gslb
@@ -36,7 +36,7 @@ The following arguments are supported:
         * `tenant_ref` - (Optional ) argument_description.
         * `third_party_sites` - (Optional ) argument_description.
             * `view_id` - (Optional ) argument_description.
-    
+
 ### Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
@@ -50,4 +50,3 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/d
 In addition to all arguments above, the following attributes are exported:
 
                                                     * `uuid` - argument_description.
-        

--- a/website/docs/r/avi_gslbgeodbprofile.html.markdown
+++ b/website/docs/r/avi_gslbgeodbprofile.html.markdown
@@ -3,7 +3,7 @@ layout: "avi"
 page_title: "Avi: avi_gslbgeodbprofile"
 sidebar_current: "docs-avi-resource-gslbgeodbprofile"
 description: |-
-Creates and manages Avi GslbGeoDbProfile.
+  Creates and manages Avi GslbGeoDbProfile.
 ---
 
 # avi_gslbgeodbprofile
@@ -28,7 +28,7 @@ The following arguments are supported:
         * `is_federated` - (Optional ) argument_description.
         * `name` - (Required) argument_description.
         * `tenant_ref` - (Optional ) argument_description.
-        
+
 ### Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
@@ -42,4 +42,3 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/d
 In addition to all arguments above, the following attributes are exported:
 
                         * `uuid` - argument_description.
-    

--- a/website/docs/r/avi_gslbservice.html.markdown
+++ b/website/docs/r/avi_gslbservice.html.markdown
@@ -3,7 +3,7 @@ layout: "avi"
 page_title: "Avi: avi_gslbservice"
 sidebar_current: "docs-avi-resource-gslbservice"
 description: |-
-Creates and manages Avi GslbService.
+  Creates and manages Avi GslbService.
 ---
 
 # avi_gslbservice
@@ -43,7 +43,7 @@ The following arguments are supported:
         * `ttl` - (Optional ) argument_description.
         * `use_edns_client_subnet` - (Optional ) argument_description.
             * `wildcard_match` - (Optional ) argument_description.
-    
+
 ### Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
@@ -57,4 +57,3 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/d
 In addition to all arguments above, the following attributes are exported:
 
                                                                                 * `uuid` - argument_description.
-        

--- a/website/docs/r/avi_hardwaresecuritymodulegroup.html.markdown
+++ b/website/docs/r/avi_hardwaresecuritymodulegroup.html.markdown
@@ -3,7 +3,7 @@ layout: "avi"
 page_title: "Avi: avi_hardwaresecuritymodulegroup"
 sidebar_current: "docs-avi-resource-hardwaresecuritymodulegroup"
 description: |-
-Creates and manages Avi HardwareSecurityModuleGroup.
+  Creates and manages Avi HardwareSecurityModuleGroup.
 ---
 
 # avi_hardwaresecuritymodulegroup
@@ -26,7 +26,7 @@ The following arguments are supported:
     * `hsm` - (Required) argument_description.
         * `name` - (Required) argument_description.
         * `tenant_ref` - (Optional ) argument_description.
-        
+
 ### Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
@@ -40,4 +40,3 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/d
 In addition to all arguments above, the following attributes are exported:
 
                 * `uuid` - argument_description.
-    

--- a/website/docs/r/avi_healthmonitor.html.markdown
+++ b/website/docs/r/avi_healthmonitor.html.markdown
@@ -3,7 +3,7 @@ layout: "avi"
 page_title: "Avi: avi_healthmonitor"
 sidebar_current: "docs-avi-resource-healthmonitor"
 description: |-
-Creates and manages Avi HealthMonitor.
+  Creates and manages Avi HealthMonitor.
 ---
 
 # avi_healthmonitor
@@ -40,7 +40,7 @@ The following arguments are supported:
         * `tenant_ref` - (Optional ) argument_description.
         * `type` - (Required) argument_description.
         * `udp_monitor` - (Optional ) argument_description.
-        
+
 ### Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
@@ -54,4 +54,3 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/d
 In addition to all arguments above, the following attributes are exported:
 
                                                                         * `uuid` - argument_description.
-    

--- a/website/docs/r/avi_httppolicyset.html.markdown
+++ b/website/docs/r/avi_httppolicyset.html.markdown
@@ -3,7 +3,7 @@ layout: "avi"
 page_title: "Avi: avi_httppolicyset"
 sidebar_current: "docs-avi-resource-httppolicyset"
 description: |-
-Creates and manages Avi HTTPPolicySet.
+  Creates and manages Avi HTTPPolicySet.
 ---
 
 # avi_httppolicyset
@@ -32,7 +32,7 @@ The following arguments are supported:
         * `is_internal_policy` - (Optional ) argument_description.
         * `name` - (Required) argument_description.
         * `tenant_ref` - (Optional ) argument_description.
-        
+
 ### Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
@@ -46,4 +46,3 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/d
 In addition to all arguments above, the following attributes are exported:
 
                                         * `uuid` - argument_description.
-    

--- a/website/docs/r/avi_ipaddrgroup.html.markdown
+++ b/website/docs/r/avi_ipaddrgroup.html.markdown
@@ -3,7 +3,7 @@ layout: "avi"
 page_title: "Avi: avi_ipaddrgroup"
 sidebar_current: "docs-avi-resource-ipaddrgroup"
 description: |-
-Creates and manages Avi IpAddrGroup.
+  Creates and manages Avi IpAddrGroup.
 ---
 
 # avi_ipaddrgroup
@@ -34,7 +34,7 @@ The following arguments are supported:
         * `prefixes` - (Optional ) argument_description.
         * `ranges` - (Optional ) argument_description.
         * `tenant_ref` - (Optional ) argument_description.
-        
+
 ### Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
@@ -48,4 +48,3 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/d
 In addition to all arguments above, the following attributes are exported:
 
                                                 * `uuid` - argument_description.
-    

--- a/website/docs/r/avi_ipamdnsproviderprofile.html.markdown
+++ b/website/docs/r/avi_ipamdnsproviderprofile.html.markdown
@@ -3,7 +3,7 @@ layout: "avi"
 page_title: "Avi: avi_ipamdnsproviderprofile"
 sidebar_current: "docs-avi-resource-ipamdnsproviderprofile"
 description: |-
-Creates and manages Avi IpamDnsProviderProfile.
+  Creates and manages Avi IpamDnsProviderProfile.
 ---
 
 # avi_ipamdnsproviderprofile
@@ -36,7 +36,7 @@ The following arguments are supported:
         * `proxy_configuration` - (Optional ) argument_description.
         * `tenant_ref` - (Optional ) argument_description.
         * `type` - (Required) argument_description.
-        
+
 ### Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
@@ -50,4 +50,3 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/d
 In addition to all arguments above, the following attributes are exported:
 
                                                         * `uuid` - argument_description.
-    

--- a/website/docs/r/avi_l4policyset.html.markdown
+++ b/website/docs/r/avi_l4policyset.html.markdown
@@ -3,7 +3,7 @@ layout: "avi"
 page_title: "Avi: avi_l4policyset"
 sidebar_current: "docs-avi-resource-l4policyset"
 description: |-
-Creates and manages Avi L4PolicySet.
+  Creates and manages Avi L4PolicySet.
 ---
 
 # avi_l4policyset
@@ -29,7 +29,7 @@ The following arguments are supported:
         * `l4_connection_policy` - (Optional ) argument_description.
         * `name` - (Optional ) argument_description.
         * `tenant_ref` - (Optional ) argument_description.
-        
+
 ### Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
@@ -43,4 +43,3 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/d
 In addition to all arguments above, the following attributes are exported:
 
                             * `uuid` - argument_description.
-    

--- a/website/docs/r/avi_microservicegroup.html.markdown
+++ b/website/docs/r/avi_microservicegroup.html.markdown
@@ -3,7 +3,7 @@ layout: "avi"
 page_title: "Avi: avi_microservicegroup"
 sidebar_current: "docs-avi-resource-microservicegroup"
 description: |-
-Creates and manages Avi MicroServiceGroup.
+  Creates and manages Avi MicroServiceGroup.
 ---
 
 # avi_microservicegroup
@@ -28,7 +28,7 @@ The following arguments are supported:
         * `name` - (Required) argument_description.
         * `service_refs` - (Optional ) argument_description.
         * `tenant_ref` - (Optional ) argument_description.
-        
+
 ### Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
@@ -42,4 +42,3 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/d
 In addition to all arguments above, the following attributes are exported:
 
                         * `uuid` - argument_description.
-    

--- a/website/docs/r/avi_network.html.markdown
+++ b/website/docs/r/avi_network.html.markdown
@@ -3,7 +3,7 @@ layout: "avi"
 page_title: "Avi: avi_network"
 sidebar_current: "docs-avi-resource-network"
 description: |-
-Creates and manages Avi Network.
+  Creates and manages Avi Network.
 ---
 
 # avi_network
@@ -33,7 +33,7 @@ The following arguments are supported:
         * `tenant_ref` - (Optional ) argument_description.
             * `vcenter_dvs` - (Optional ) argument_description.
         * `vrf_context_ref` - (Optional ) argument_description.
-    
+
 ### Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
@@ -47,4 +47,3 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/d
 In addition to all arguments above, the following attributes are exported:
 
                                     * `uuid` - argument_description.
-            

--- a/website/docs/r/avi_networkprofile.html.markdown
+++ b/website/docs/r/avi_networkprofile.html.markdown
@@ -3,7 +3,7 @@ layout: "avi"
 page_title: "Avi: avi_networkprofile"
 sidebar_current: "docs-avi-resource-networkprofile"
 description: |-
-Creates and manages Avi NetworkProfile.
+  Creates and manages Avi NetworkProfile.
 ---
 
 # avi_networkprofile
@@ -28,7 +28,7 @@ The following arguments are supported:
         * `name` - (Required) argument_description.
         * `profile` - (Required) argument_description.
         * `tenant_ref` - (Optional ) argument_description.
-        
+
 ### Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
@@ -42,4 +42,3 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/d
 In addition to all arguments above, the following attributes are exported:
 
                         * `uuid` - argument_description.
-    

--- a/website/docs/r/avi_networksecuritypolicy.html.markdown
+++ b/website/docs/r/avi_networksecuritypolicy.html.markdown
@@ -3,7 +3,7 @@ layout: "avi"
 page_title: "Avi: avi_networksecuritypolicy"
 sidebar_current: "docs-avi-resource-networksecuritypolicy"
 description: |-
-Creates and manages Avi NetworkSecurityPolicy.
+  Creates and manages Avi NetworkSecurityPolicy.
 ---
 
 # avi_networksecuritypolicy
@@ -29,7 +29,7 @@ The following arguments are supported:
         * `name` - (Optional ) argument_description.
         * `rules` - (Optional ) argument_description.
         * `tenant_ref` - (Optional ) argument_description.
-        
+
 ### Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
@@ -43,4 +43,3 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/d
 In addition to all arguments above, the following attributes are exported:
 
                             * `uuid` - argument_description.
-    

--- a/website/docs/r/avi_pkiprofile.html.markdown
+++ b/website/docs/r/avi_pkiprofile.html.markdown
@@ -3,7 +3,7 @@ layout: "avi"
 page_title: "Avi: avi_pkiprofile"
 sidebar_current: "docs-avi-resource-pkiprofile"
 description: |-
-Creates and manages Avi PKIProfile.
+  Creates and manages Avi PKIProfile.
 ---
 
 # avi_pkiprofile
@@ -32,7 +32,7 @@ The following arguments are supported:
         * `name` - (Required) argument_description.
         * `tenant_ref` - (Optional ) argument_description.
             * `validate_only_leaf_crl` - (Optional ) argument_description.
-    
+
 ### Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
@@ -46,4 +46,3 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/d
 In addition to all arguments above, the following attributes are exported:
 
                                     * `uuid` - argument_description.
-        

--- a/website/docs/r/avi_pool.html.markdown
+++ b/website/docs/r/avi_pool.html.markdown
@@ -3,7 +3,7 @@ layout: "avi"
 page_title: "Avi: avi_pool"
 sidebar_current: "docs-avi-resource-pool"
 description: |-
-Creates and manages Avi Pool.
+  Creates and manages Avi Pool.
 ---
 
 # avi_pool
@@ -73,7 +73,7 @@ The following arguments are supported:
         * `tenant_ref` - (Optional ) argument_description.
         * `use_service_port` - (Optional ) argument_description.
             * `vrf_ref` - (Optional ) argument_description.
-    
+
 ### Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
@@ -87,4 +87,3 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/d
 In addition to all arguments above, the following attributes are exported:
 
                                                                                                                                                                                                         * `uuid` - argument_description.
-        

--- a/website/docs/r/avi_poolgroup.html.markdown
+++ b/website/docs/r/avi_poolgroup.html.markdown
@@ -3,7 +3,7 @@ layout: "avi"
 page_title: "Avi: avi_poolgroup"
 sidebar_current: "docs-avi-resource-poolgroup"
 description: |-
-Creates and manages Avi PoolGroup.
+  Creates and manages Avi PoolGroup.
 ---
 
 # avi_poolgroup
@@ -35,7 +35,7 @@ The following arguments are supported:
         * `name` - (Required) argument_description.
         * `priority_labels_ref` - (Optional ) argument_description.
         * `tenant_ref` - (Optional ) argument_description.
-        
+
 ### Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
@@ -49,4 +49,3 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/d
 In addition to all arguments above, the following attributes are exported:
 
                                                     * `uuid` - argument_description.
-    

--- a/website/docs/r/avi_poolgroupdeploymentpolicy.html.markdown
+++ b/website/docs/r/avi_poolgroupdeploymentpolicy.html.markdown
@@ -3,7 +3,7 @@ layout: "avi"
 page_title: "Avi: avi_poolgroupdeploymentpolicy"
 sidebar_current: "docs-avi-resource-poolgroupdeploymentpolicy"
 description: |-
-Creates and manages Avi PoolGroupDeploymentPolicy.
+  Creates and manages Avi PoolGroupDeploymentPolicy.
 ---
 
 # avi_poolgroupdeploymentpolicy
@@ -33,7 +33,7 @@ The following arguments are supported:
         * `tenant_ref` - (Optional ) argument_description.
         * `test_traffic_ratio_rampup` - (Optional ) argument_description.
             * `webhook_ref` - (Optional ) argument_description.
-    
+
 ### Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
@@ -47,4 +47,3 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/d
 In addition to all arguments above, the following attributes are exported:
 
                                         * `uuid` - argument_description.
-        

--- a/website/docs/r/avi_prioritylabels.html.markdown
+++ b/website/docs/r/avi_prioritylabels.html.markdown
@@ -3,7 +3,7 @@ layout: "avi"
 page_title: "Avi: avi_prioritylabels"
 sidebar_current: "docs-avi-resource-prioritylabels"
 description: |-
-Creates and manages Avi PriorityLabels.
+  Creates and manages Avi PriorityLabels.
 ---
 
 # avi_prioritylabels
@@ -28,7 +28,7 @@ The following arguments are supported:
         * `equivalent_labels` - (Optional ) argument_description.
         * `name` - (Required) argument_description.
         * `tenant_ref` - (Optional ) argument_description.
-        
+
 ### Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
@@ -42,4 +42,3 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/d
 In addition to all arguments above, the following attributes are exported:
 
                         * `uuid` - argument_description.
-    

--- a/website/docs/r/avi_role.html.markdown
+++ b/website/docs/r/avi_role.html.markdown
@@ -3,7 +3,7 @@ layout: "avi"
 page_title: "Avi: avi_role"
 sidebar_current: "docs-avi-resource-role"
 description: |-
-Creates and manages Avi Role.
+  Creates and manages Avi Role.
 ---
 
 # avi_role
@@ -26,7 +26,7 @@ The following arguments are supported:
     * `name` - (Required) argument_description.
         * `privileges` - (Optional ) argument_description.
         * `tenant_ref` - (Optional ) argument_description.
-        
+
 ### Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
@@ -40,4 +40,3 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/d
 In addition to all arguments above, the following attributes are exported:
 
                 * `uuid` - argument_description.
-    

--- a/website/docs/r/avi_scheduler.html.markdown
+++ b/website/docs/r/avi_scheduler.html.markdown
@@ -3,7 +3,7 @@ layout: "avi"
 page_title: "Avi: avi_scheduler"
 sidebar_current: "docs-avi-resource-scheduler"
 description: |-
-Creates and manages Avi Scheduler.
+  Creates and manages Avi Scheduler.
 ---
 
 # avi_scheduler
@@ -34,7 +34,7 @@ The following arguments are supported:
         * `scheduler_action` - (Optional ) argument_description.
         * `start_date_time` - (Optional ) argument_description.
         * `tenant_ref` - (Optional ) argument_description.
-        
+
 ### Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
@@ -48,4 +48,3 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/d
 In addition to all arguments above, the following attributes are exported:
 
                                                 * `uuid` - argument_description.
-    

--- a/website/docs/r/avi_seproperties.html.markdown
+++ b/website/docs/r/avi_seproperties.html.markdown
@@ -3,7 +3,7 @@ layout: "avi"
 page_title: "Avi: avi_seproperties"
 sidebar_current: "docs-avi-resource-seproperties"
 description: |-
-Creates and manages Avi SeProperties.
+  Creates and manages Avi SeProperties.
 ---
 
 # avi_seproperties
@@ -26,7 +26,7 @@ The following arguments are supported:
     * `se_agent_properties` - (Optional ) argument_description.
         * `se_bootup_properties` - (Optional ) argument_description.
         * `se_runtime_properties` - (Optional ) argument_description.
-        
+
 ### Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
@@ -40,4 +40,3 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/d
 In addition to all arguments above, the following attributes are exported:
 
                 * `uuid` - argument_description.
-    

--- a/website/docs/r/avi_server.html.markdown
+++ b/website/docs/r/avi_server.html.markdown
@@ -3,7 +3,7 @@ layout: "avi"
 page_title: "Avi: avi_server"
 sidebar_current: "docs-avi-resource-server"
 description: |-
-Creates and manages Avi Server.
+  Creates and manages Avi Server.
 ---
 
 # avi_server
@@ -38,7 +38,7 @@ The following arguments are supported:
     * `prst_hdr_val` - (Optional ) argument_description.
     * `rewrite_host_header` - (Optional ) argument_description.
     * `vm_ref` - (Optional ) argument_description.
-    
+
 ### Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
@@ -52,4 +52,3 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/d
 In addition to all arguments above, the following attributes are exported:
 
                                                                                                                                                                                                         * `uuid` - argument_description.
-        

--- a/website/docs/r/avi_serverautoscalepolicy.html.markdown
+++ b/website/docs/r/avi_serverautoscalepolicy.html.markdown
@@ -3,7 +3,7 @@ layout: "avi"
 page_title: "Avi: avi_serverautoscalepolicy"
 sidebar_current: "docs-avi-resource-serverautoscalepolicy"
 description: |-
-Creates and manages Avi ServerAutoScalePolicy.
+  Creates and manages Avi ServerAutoScalePolicy.
 ---
 
 # avi_serverautoscalepolicy
@@ -38,7 +38,7 @@ The following arguments are supported:
         * `scaleout_cooldown` - (Optional ) argument_description.
         * `tenant_ref` - (Optional ) argument_description.
         * `use_predicted_load` - (Optional ) argument_description.
-        
+
 ### Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
@@ -52,4 +52,3 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/d
 In addition to all arguments above, the following attributes are exported:
 
                                                                 * `uuid` - argument_description.
-    

--- a/website/docs/r/avi_serviceengine.html.markdown
+++ b/website/docs/r/avi_serviceengine.html.markdown
@@ -3,7 +3,7 @@ layout: "avi"
 page_title: "Avi: avi_serviceengine"
 sidebar_current: "docs-avi-resource-serviceengine"
 description: |-
-Creates and manages Avi ServiceEngine.
+  Creates and manages Avi ServiceEngine.
 ---
 
 # avi_serviceengine
@@ -39,7 +39,7 @@ The following arguments are supported:
         * `resources` - (Optional ) argument_description.
         * `se_group_ref` - (Optional ) argument_description.
         * `tenant_ref` - (Optional ) argument_description.
-        
+
 ### Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
@@ -53,4 +53,3 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/d
 In addition to all arguments above, the following attributes are exported:
 
                                                                     * `uuid` - argument_description.
-    

--- a/website/docs/r/avi_serviceenginegroup.html.markdown
+++ b/website/docs/r/avi_serviceenginegroup.html.markdown
@@ -3,7 +3,7 @@ layout: "avi"
 page_title: "Avi: avi_serviceenginegroup"
 sidebar_current: "docs-avi-resource-serviceenginegroup"
 description: |-
-Creates and manages Avi ServiceEngineGroup.
+  Creates and manages Avi ServiceEngineGroup.
 ---
 
 # avi_serviceenginegroup
@@ -155,7 +155,7 @@ The following arguments are supported:
         * `waf_learning_memory` - (Optional ) argument_description.
         * `waf_mempool` - (Optional ) argument_description.
         * `waf_mempool_size` - (Optional ) argument_description.
-    
+
 ### Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
@@ -169,4 +169,3 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/d
 In addition to all arguments above, the following attributes are exported:
 
                                                                                                                                                                                                                                                                                                                                                                                                                                                                             * `uuid` - argument_description.
-                                                                            

--- a/website/docs/r/avi_snmptrapprofile.html.markdown
+++ b/website/docs/r/avi_snmptrapprofile.html.markdown
@@ -3,7 +3,7 @@ layout: "avi"
 page_title: "Avi: avi_snmptrapprofile"
 sidebar_current: "docs-avi-resource-snmptrapprofile"
 description: |-
-Creates and manages Avi SnmpTrapProfile.
+  Creates and manages Avi SnmpTrapProfile.
 ---
 
 # avi_snmptrapprofile
@@ -26,7 +26,7 @@ The following arguments are supported:
     * `name` - (Required) argument_description.
         * `tenant_ref` - (Optional ) argument_description.
         * `trap_servers` - (Optional ) argument_description.
-        
+
 ### Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
@@ -40,4 +40,3 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/d
 In addition to all arguments above, the following attributes are exported:
 
                 * `uuid` - argument_description.
-    

--- a/website/docs/r/avi_sslkeyandcertificate.html.markdown
+++ b/website/docs/r/avi_sslkeyandcertificate.html.markdown
@@ -3,7 +3,7 @@ layout: "avi"
 page_title: "Avi: avi_sslkeyandcertificate"
 sidebar_current: "docs-avi-resource-sslkeyandcertificate"
 description: |-
-Creates and manages Avi SSLKeyAndCertificate.
+  Creates and manages Avi SSLKeyAndCertificate.
 ---
 
 # avi_sslkeyandcertificate
@@ -41,7 +41,7 @@ The following arguments are supported:
         * `status` - (Optional ) argument_description.
         * `tenant_ref` - (Optional ) argument_description.
         * `type` - (Optional ) argument_description.
-        
+
 ### Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
@@ -55,4 +55,3 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/d
 In addition to all arguments above, the following attributes are exported:
 
                                                                             * `uuid` - argument_description.
-    

--- a/website/docs/r/avi_sslprofile.html.markdown
+++ b/website/docs/r/avi_sslprofile.html.markdown
@@ -3,7 +3,7 @@ layout: "avi"
 page_title: "Avi: avi_sslprofile"
 sidebar_current: "docs-avi-resource-sslprofile"
 description: |-
-Creates and manages Avi SSLProfile.
+  Creates and manages Avi SSLProfile.
 ---
 
 # avi_sslprofile
@@ -37,7 +37,7 @@ The following arguments are supported:
         * `tags` - (Optional ) argument_description.
         * `tenant_ref` - (Optional ) argument_description.
         * `type` - (Optional ) argument_description.
-        
+
 ### Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
@@ -51,4 +51,3 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/d
 In addition to all arguments above, the following attributes are exported:
 
                                                             * `uuid` - argument_description.
-    

--- a/website/docs/r/avi_stringgroup.html.markdown
+++ b/website/docs/r/avi_stringgroup.html.markdown
@@ -3,7 +3,7 @@ layout: "avi"
 page_title: "Avi: avi_stringgroup"
 sidebar_current: "docs-avi-resource-stringgroup"
 description: |-
-Creates and manages Avi StringGroup.
+  Creates and manages Avi StringGroup.
 ---
 
 # avi_stringgroup
@@ -28,7 +28,7 @@ The following arguments are supported:
         * `name` - (Required) argument_description.
         * `tenant_ref` - (Optional ) argument_description.
         * `type` - (Required) argument_description.
-        
+
 ### Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
@@ -42,4 +42,3 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/d
 In addition to all arguments above, the following attributes are exported:
 
                         * `uuid` - argument_description.
-    

--- a/website/docs/r/avi_systemconfiguration.html.markdown
+++ b/website/docs/r/avi_systemconfiguration.html.markdown
@@ -3,7 +3,7 @@ layout: "avi"
 page_title: "Avi: avi_systemconfiguration"
 sidebar_current: "docs-avi-resource-systemconfiguration"
 description: |-
-Creates and manages Avi SystemConfiguration.
+  Creates and manages Avi SystemConfiguration.
 ---
 
 # avi_systemconfiguration
@@ -38,7 +38,7 @@ The following arguments are supported:
         * `snmp_configuration` - (Optional ) argument_description.
         * `ssh_ciphers` - (Optional ) argument_description.
         * `ssh_hmacs` - (Optional ) argument_description.
-        
+
 ### Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
@@ -52,4 +52,3 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/d
 In addition to all arguments above, the following attributes are exported:
 
                                                                 * `uuid` - argument_description.
-    

--- a/website/docs/r/avi_tenant.html.markdown
+++ b/website/docs/r/avi_tenant.html.markdown
@@ -3,7 +3,7 @@ layout: "avi"
 page_title: "Avi: avi_tenant"
 sidebar_current: "docs-avi-resource-tenant"
 description: |-
-Creates and manages Avi Tenant.
+  Creates and manages Avi Tenant.
 ---
 
 # avi_tenant
@@ -28,7 +28,7 @@ The following arguments are supported:
         * `description` - (Optional ) argument_description.
         * `local` - (Optional ) argument_description.
         * `name` - (Required) argument_description.
-        
+
 ### Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
@@ -42,4 +42,3 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/d
 In addition to all arguments above, the following attributes are exported:
 
                         * `uuid` - argument_description.
-    

--- a/website/docs/r/avi_trafficcloneprofile.html.markdown
+++ b/website/docs/r/avi_trafficcloneprofile.html.markdown
@@ -3,7 +3,7 @@ layout: "avi"
 page_title: "Avi: avi_trafficcloneprofile"
 sidebar_current: "docs-avi-resource-trafficcloneprofile"
 description: |-
-Creates and manages Avi TrafficCloneProfile.
+  Creates and manages Avi TrafficCloneProfile.
 ---
 
 # avi_trafficcloneprofile
@@ -28,7 +28,7 @@ The following arguments are supported:
         * `name` - (Required) argument_description.
         * `preserve_client_ip` - (Optional ) argument_description.
         * `tenant_ref` - (Optional ) argument_description.
-        
+
 ### Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
@@ -42,4 +42,3 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/d
 In addition to all arguments above, the following attributes are exported:
 
                         * `uuid` - argument_description.
-    

--- a/website/docs/r/avi_useraccountprofile.html.markdown
+++ b/website/docs/r/avi_useraccountprofile.html.markdown
@@ -3,7 +3,7 @@ layout: "avi"
 page_title: "Avi: avi_useraccountprofile"
 sidebar_current: "docs-avi-resource-useraccountprofile"
 description: |-
-Creates and manages Avi UserAccountProfile.
+  Creates and manages Avi UserAccountProfile.
 ---
 
 # avi_useraccountprofile
@@ -29,7 +29,7 @@ The following arguments are supported:
         * `max_login_failure_count` - (Optional ) argument_description.
         * `max_password_history_count` - (Optional ) argument_description.
         * `name` - (Required) argument_description.
-        
+
 ### Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
@@ -43,4 +43,3 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/d
 In addition to all arguments above, the following attributes are exported:
 
                             * `uuid` - argument_description.
-    

--- a/website/docs/r/avi_virtualservice.html.markdown
+++ b/website/docs/r/avi_virtualservice.html.markdown
@@ -3,7 +3,7 @@ layout: "avi"
 page_title: "Avi: avi_virtualservice"
 sidebar_current: "docs-avi-resource-virtualservice"
 description: |-
-Creates and manages Avi VirtualService.
+  Creates and manages Avi VirtualService.
 ---
 
 # avi_virtualservice
@@ -93,7 +93,7 @@ The following arguments are supported:
         * `vsvip_ref` - (Optional ) argument_description.
         * `waf_policy_ref` - (Optional ) argument_description.
         * `weight` - (Optional ) argument_description.
-    
+
 ### Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
@@ -107,4 +107,3 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/d
 In addition to all arguments above, the following attributes are exported:
 
                                                                                                                                                                                                                                                         * `uuid` - argument_description.
-                                        

--- a/website/docs/r/avi_vrfcontext.html.markdown
+++ b/website/docs/r/avi_vrfcontext.html.markdown
@@ -3,7 +3,7 @@ layout: "avi"
 page_title: "Avi: avi_vrfcontext"
 sidebar_current: "docs-avi-resource-vrfcontext"
 description: |-
-Creates and manages Avi VrfContext.
+  Creates and manages Avi VrfContext.
 ---
 
 # avi_vrfcontext
@@ -33,7 +33,7 @@ The following arguments are supported:
         * `static_routes` - (Optional ) argument_description.
         * `system_default` - (Optional ) argument_description.
         * `tenant_ref` - (Optional ) argument_description.
-        
+
 ### Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
@@ -47,4 +47,3 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/d
 In addition to all arguments above, the following attributes are exported:
 
                                             * `uuid` - argument_description.
-    

--- a/website/docs/r/avi_vsdatascriptset.html.markdown
+++ b/website/docs/r/avi_vsdatascriptset.html.markdown
@@ -3,7 +3,7 @@ layout: "avi"
 page_title: "Avi: avi_vsdatascriptset"
 sidebar_current: "docs-avi-resource-vsdatascriptset"
 description: |-
-Creates and manages Avi VSDataScriptSet.
+  Creates and manages Avi VSDataScriptSet.
 ---
 
 # avi_vsdatascriptset
@@ -32,7 +32,7 @@ The following arguments are supported:
         * `pool_refs` - (Optional ) argument_description.
         * `string_group_refs` - (Optional ) argument_description.
         * `tenant_ref` - (Optional ) argument_description.
-        
+
 ### Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
@@ -46,4 +46,3 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/d
 In addition to all arguments above, the following attributes are exported:
 
                                         * `uuid` - argument_description.
-    

--- a/website/docs/r/avi_vsvip.html.markdown
+++ b/website/docs/r/avi_vsvip.html.markdown
@@ -3,7 +3,7 @@ layout: "avi"
 page_title: "Avi: avi_vsvip"
 sidebar_current: "docs-avi-resource-vsvip"
 description: |-
-Creates and manages Avi VsVip.
+  Creates and manages Avi VsVip.
 ---
 
 # avi_vsvip
@@ -31,7 +31,7 @@ The following arguments are supported:
             * `vip` - (Optional ) argument_description.
         * `vrf_context_ref` - (Optional ) argument_description.
         * `vsvip_cloud_config_cksum` - (Optional ) argument_description.
-    
+
 ### Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
@@ -45,4 +45,3 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/d
 In addition to all arguments above, the following attributes are exported:
 
                         * `uuid` - argument_description.
-                

--- a/website/docs/r/avi_wafpolicy.html.markdown
+++ b/website/docs/r/avi_wafpolicy.html.markdown
@@ -3,7 +3,7 @@ layout: "avi"
 page_title: "Avi: avi_wafpolicy"
 sidebar_current: "docs-avi-resource-wafpolicy"
 description: |-
-Creates and manages Avi WafPolicy.
+  Creates and manages Avi WafPolicy.
 ---
 
 # avi_wafpolicy
@@ -36,7 +36,7 @@ The following arguments are supported:
         * `tenant_ref` - (Optional ) argument_description.
             * `waf_crs_ref` - (Optional ) argument_description.
         * `waf_profile_ref` - (Optional ) argument_description.
-    
+
 ### Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
@@ -50,4 +50,3 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/d
 In addition to all arguments above, the following attributes are exported:
 
                                                 * `uuid` - argument_description.
-            

--- a/website/docs/r/avi_wafprofile.html.markdown
+++ b/website/docs/r/avi_wafprofile.html.markdown
@@ -3,7 +3,7 @@ layout: "avi"
 page_title: "Avi: avi_wafprofile"
 sidebar_current: "docs-avi-resource-wafprofile"
 description: |-
-Creates and manages Avi WafProfile.
+  Creates and manages Avi WafProfile.
 ---
 
 # avi_wafprofile
@@ -28,7 +28,7 @@ The following arguments are supported:
         * `files` - (Optional ) argument_description.
         * `name` - (Required) argument_description.
         * `tenant_ref` - (Optional ) argument_description.
-        
+
 ### Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
@@ -42,4 +42,3 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/d
 In addition to all arguments above, the following attributes are exported:
 
                         * `uuid` - argument_description.
-    

--- a/website/docs/r/avi_webhook.html.markdown
+++ b/website/docs/r/avi_webhook.html.markdown
@@ -3,7 +3,7 @@ layout: "avi"
 page_title: "Avi: avi_webhook"
 sidebar_current: "docs-avi-resource-webhook"
 description: |-
-Creates and manages Avi Webhook.
+  Creates and manages Avi Webhook.
 ---
 
 # avi_webhook
@@ -28,7 +28,7 @@ The following arguments are supported:
         * `name` - (Required) argument_description.
         * `tenant_ref` - (Optional ) argument_description.
             * `verification_token` - (Optional ) argument_description.
-    
+
 ### Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
@@ -42,4 +42,3 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/d
 In addition to all arguments above, the following attributes are exported:
 
                     * `uuid` - argument_description.
-        


### PR DESCRIPTION
Hey Team, 

This is the last change needed before moving on to the technical review of the Terraform Provider Development Program.

The Tab must be added for the terraform.io middleman to deploy the documentation correctly

Let me know if you have any questions.

Best,
Chris 