### PR TITLE
Update to ResourceVipSchema

### DIFF
--- a/avi/resource_avi_rest_dependants.go
+++ b/avi/resource_avi_rest_dependants.go
@@ -8073,34 +8073,41 @@ func ResourceVipSchema() *schema.Resource {
 			"floating_ip": &schema.Schema{
 				Type:     schema.TypeSet,
 				Optional: true,
+				Computed: true,
 				Elem:     ResourceIpAddrSchema(),
 			},
 			"floating_ip6": &schema.Schema{
 				Type:     schema.TypeSet,
 				Optional: true,
+				Computed: true,
 				Elem:     ResourceIpAddrSchema(),
 			},
 			"floating_subnet6_uuid": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 			},
 			"floating_subnet_uuid": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 			},
 			"ip6_address": &schema.Schema{
 				Type:     schema.TypeSet,
 				Optional: true,
+				Computed: true,
 				Elem:     ResourceIpAddrSchema(),
 			},
 			"ip_address": &schema.Schema{
 				Type:     schema.TypeSet,
 				Optional: true,
+				Computed: true,
 				Elem:     ResourceIpAddrSchema(),
 			},
 			"ipam_network_subnet": &schema.Schema{
 				Type:     schema.TypeSet,
 				Optional: true,
+				Computed: true,
 				Elem:     ResourceIPNetworkSubnetSchema(),
 			},
 			"network_ref": &schema.Schema{
@@ -8111,28 +8118,34 @@ func ResourceVipSchema() *schema.Resource {
 			"port_uuid": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 			},
 			"subnet": &schema.Schema{
 				Type:     schema.TypeSet,
 				Optional: true,
+				Computed: true,
 				Elem:     ResourceIpAddrPrefixSchema(),
 			},
 			"subnet6": &schema.Schema{
 				Type:     schema.TypeSet,
 				Optional: true,
+				Computed: true,
 				Elem:     ResourceIpAddrPrefixSchema(),
 			},
 			"subnet6_uuid": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 			},
 			"subnet_uuid": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 			},
 			"vip_id": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 			},
 		},
 	}


### PR DESCRIPTION
in resource_avi_rest_dependants.go

Added "Computed: true," to several attributes that might be
computed at resource creation.

Without this, any references to these attributes in other resource
definitions in terraform code will fail.

Example TF code:

```
resource "avi_virtualservice" "test" {
  ...

  vip {
    auto_allocate_ip  = true
    avi_allocated_vip = true
    subnet_uuid       = "${var.subnet_id}"
  }
}

resource "openstack_dns_recordset_v2" "avi" {
  region      = "${var.region}"
  zone_id     = "${var.zone_id}"
  name        = "avi.${var.zone}"
  description = "A record to avi virtual service"
  ttl         = 300
  type        = "A"
  records     = ["${lookup(avi_virtualservice.test.vip.0.ip_address[0], "addr")}"]
}
```

This code fails at terraform plan, with error:

```
Error: Error refreshing state: 1 error(s) occurred:

* openstack_dns_recordset_v2.avi: 1 error(s) occurred:

* openstack_dns_recordset_v2.avi: At column 50, line 1: invalid index operation into non-indexable type: TypeString in:

${lookup(avi_virtualservice.test.vip.0.ip_address[0], "addr")}
```

After building the provider binary with the "Computed: true," line added for the ip_address attribute,
the terraform plan and apply run without problems.

As such, I went through the list of attributes that are Optional and marked all
that might be computed with "Computed: true,"