### PR TITLE
AV-63162 Modified tests for new changes done with terraform datasources.

### DIFF
--- a/avi/provider_test.go
+++ b/avi/provider_test.go
@@ -43,26 +43,27 @@ func TestProvider(t *testing.T) {
 	}
 
 	// Validating pool resource in avi provider and datasource for pool
-	var poolconfigs = map[string]interface{}{"name": "", "uuid": "",
-		"health_monitor_refs": make([]string, 0), "servers": make([]string, 0),
-		"fail_action": make([]string, 0)}
+	var poolconfigs_data = map[string]interface{}{"name": ""}
 
 	_, errs = Provider().(*schema.Provider).ValidateDataSource("avi_pool",
-		&terraform.ResourceConfig{Config: poolconfigs})
+		&terraform.ResourceConfig{Config: poolconfigs_data})
 	if errs != nil {
 		t.Fatalf("err: %s", errs)
 	}
 
+    var poolconfigs_res = map[string]interface{}{"name": "", "uuid": "",
+       "health_monitor_refs": make([]string, 0), "servers": make([]string, 0),
+       "fail_action": make([]string, 0)}
+
 	_, errs = Provider().(*schema.Provider).ValidateResource("avi_pool",
-		&terraform.ResourceConfig{Config: poolconfigs})
+		&terraform.ResourceConfig{Config: poolconfigs_res})
 	if errs != nil {
 		t.Fatalf("err: %s", errs)
 	}
 
 	// Validating pool resource in avi provider and datasource for pool
 
-	var hmconfigs = map[string]interface{}{"name": "", "uuid": "",
-		"type": ""}
+	var hmconfigs_data = map[string]interface{}{"name": ""}
 
 	_, errs = Provider().(*schema.Provider).ValidateDataSource(
 		"avi_healthmonitor", &terraform.ResourceConfig{Config: hmconfigs})
@@ -70,8 +71,11 @@ func TestProvider(t *testing.T) {
 		t.Fatalf("err: %s", errs)
 	}
 
+    var hmconfigs_res = map[string]interface{}{"name": "", "uuid": "",
+        "type": ""}
+
 	_, errs = Provider().(*schema.Provider).ValidateResource(
-		"avi_healthmonitor", &terraform.ResourceConfig{Config: hmconfigs})
+		"avi_healthmonitor", &terraform.ResourceConfig{Config: hmconfigs_res})
 	if errs != nil {
 		t.Fatalf("err: %s", errs)
 	}


### PR DESCRIPTION
Before this PR, please merge this PR (https://github.com/avinetworks/avi-dev/pull/51071) and auto-generate terraform resources. Compute field changes in datasources leads to failure of provider_test.go. So we need to update provider_test.go when datasources are updated with compute field changes.