### PR TITLE
Updated syntax for Makefile

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,5 +1,5 @@
-TEST?=$$(go list ./... |grep -v 'vendor')
-GOFMT_FILES?=$$(find . -name '*.go' |grep -v vendor)
+TEST?=$$(go list ./... | grep -v 'vendor')
+GOFMT_FILES?=$$(find . -name '*.go' | grep -v vendor)
 
 default: build
 


### PR DESCRIPTION
When trying to build the provider I was getting an error on the first two lines regarding the gofmt command. Adding a space between the | and grep seemed to fix the issue. Let me know if you have any questions.