### PR TITLE
Adding functionality to suppress changes to sensitive fields

### DIFF
--- a/avi/diff_suppress_funcs.go
+++ b/avi/diff_suppress_funcs.go
@@ -1,0 +1,16 @@
+package avi
+
+import (
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func suppressPassphraseDiffs(k, old, new string, d *schema.ResourceData) bool {
+	if d.Get("changed").(bool) {
+		return false
+	}
+	return true
+}
+
+func suppressChangedDiffs(k, old, new string, d *schema.ResourceData) bool {
+	return old == "true" && new == "false"
+}

--- a/avi/resource_avi_backupconfiguration.go
+++ b/avi/resource_avi_backupconfiguration.go
@@ -35,9 +35,10 @@ func ResourceBackupConfigurationSchema() map[string]*schema.Schema {
 			Computed: true,
 		},
 		"backup_passphrase": {
-			Type:     schema.TypeString,
-			Optional: true,
-			Computed: true,
+			Type:     	  schema.TypeString,
+			Optional: 	  true,
+			Computed: 	  true,
+			DiffSuppressFunc: suppressPassphraseDiffs,
 		},
 		"maximum_backups_stored": {
 			Type:     schema.TypeInt,
@@ -83,6 +84,11 @@ func ResourceBackupConfigurationSchema() map[string]*schema.Schema {
 			Optional: true,
 			Computed: true,
 		},
+		"changed": {
+                        Type:             schema.TypeBool,
+                        Optional:         true,
+                        DiffSuppressFunc: suppressChangedDiffs,
+                },
 		"uuid": {
 			Type:     schema.TypeString,
 			Optional: true,

--- a/avi/resource_avi_backupconfiguration.go
+++ b/avi/resource_avi_backupconfiguration.go
@@ -87,6 +87,7 @@ func ResourceBackupConfigurationSchema() map[string]*schema.Schema {
 		"changed": {
                         Type:             schema.TypeBool,
                         Optional:         true,
+			Default:	  true,
                         DiffSuppressFunc: suppressChangedDiffs,
                 },
 		"uuid": {

--- a/avi/resource_avi_backupconfiguration.go
+++ b/avi/resource_avi_backupconfiguration.go
@@ -87,7 +87,7 @@ func ResourceBackupConfigurationSchema() map[string]*schema.Schema {
 		"changed": {
                         Type:             schema.TypeBool,
                         Optional:         true,
-			Default:	  true,
+                        Default:          true,
                         DiffSuppressFunc: suppressChangedDiffs,
                 },
 		"uuid": {

--- a/avi/resource_avi_backupconfiguration.go
+++ b/avi/resource_avi_backupconfiguration.go
@@ -35,9 +35,9 @@ func ResourceBackupConfigurationSchema() map[string]*schema.Schema {
 			Computed: true,
 		},
 		"backup_passphrase": {
-			Type:     	  schema.TypeString,
-			Optional: 	  true,
-			Computed: 	  true,
+			Type:             schema.TypeString,
+			Optional:         true,
+			Computed:         true,
 			DiffSuppressFunc: suppressPassphraseDiffs,
 		},
 		"maximum_backups_stored": {
@@ -85,11 +85,11 @@ func ResourceBackupConfigurationSchema() map[string]*schema.Schema {
 			Computed: true,
 		},
 		"changed": {
-                        Type:             schema.TypeBool,
-                        Optional:         true,
-                        Default:          true,
-                        DiffSuppressFunc: suppressChangedDiffs,
-                },
+			Type:             schema.TypeBool,
+			Optional:         true,
+			Default:          true,
+			DiffSuppressFunc: suppressChangedDiffs,
+		},
 		"uuid": {
 			Type:     schema.TypeString,
 			Optional: true,


### PR DESCRIPTION
Added functionality to suppress diffs for sensitive fields.
Currently, I have only added it for backup configuration but it can be extended to all resources with sensitive fields.

For the backup passphrase resource:

- added a new parameter "changed" to the schema.
- The default value for this will be true, to preserve the current behavior.
- The changes will be suppressed using DiffSuppressFuncs.

Working:

- Add "changed: false" to the resource definition in the terraform plan to suppress the changes.
- Adding "changed: false" while creation will result in the backup_passphrase not being set.
- For any subsequent changes to the passphrase, set "changed: true" or do not include changed in the plan(since it will assume the default value i.e.true).